### PR TITLE
Feat/v0.4 launch prep

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,3 +3,12 @@ JWT_SECRET=change-this-to-a-random-secret
 PORT=8080
 REDIS_URL=redis://localhost:6380
 DEPLOYMENT_MODE=self-hosted
+
+# URL where the SPA is served from (used for CORS origins).
+FRONTEND_URL=http://localhost:5173
+
+# Public URL where this SendDock instance is reachable from the internet.
+# Used to build unsubscribe links and tracking pixel URLs in outgoing emails.
+# In single-binary deploys this is usually the same as FRONTEND_URL and you can leave it blank.
+# Example: PUBLIC_URL=https://email.mycompany.com
+PUBLIC_URL=

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -64,7 +64,7 @@ func main() {
 	apiKeyService := service.NewAPIKeyService(queries)
 	apiKeyHandler := handler.NewAPIKeyHandler(apiKeyService, projectService)
 
-	emailService := service.NewEmailService(queries, cfg.FrontendURL, cfg.JWTSecret, redisCache)
+	emailService := service.NewEmailService(queries, cfg.PublicURL, cfg.JWTSecret, redisCache)
 	emailHandler := handler.NewEmailHandler(emailService, projectService)
 
 	campaignService := service.NewCampaignService(queries)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1,6 +1,10 @@
 package config
 
-import "os"
+import (
+	"log"
+	"os"
+	"strings"
+)
 
 type Config struct {
 	Port           string
@@ -8,17 +12,31 @@ type Config struct {
 	RedisUrl       string
 	JWTSecret      string
 	FrontendURL    string
+	PublicURL      string
 	DeploymentMode string
 }
 
 func Load() Config {
+	frontendURL := getEnv("FRONTEND_URL", "http://localhost:5173")
+	publicURL := getEnv("PUBLIC_URL", "")
+	if publicURL == "" {
+		publicURL = frontendURL
+	}
+	publicURL = strings.TrimRight(publicURL, "/")
+
+	mode := getEnv("DEPLOYMENT_MODE", "self-hosted")
+	if mode != "cloud" && strings.HasPrefix(publicURL, "http://localhost") {
+		log.Println("WARNING: PUBLIC_URL is set to localhost. Unsubscribe and tracking links in outgoing emails will not work outside this machine. Set PUBLIC_URL in your .env to the URL where this instance is reachable from the internet.")
+	}
+
 	return Config{
 		Port:           getEnv("PORT", "8080"),
 		DatabaseUrl:    getEnv("DATABASE_URL", ""),
 		RedisUrl:       getEnv("REDIS_URL", ""),
 		JWTSecret:      getEnv("JWT_SECRET", ""),
-		FrontendURL:    getEnv("FRONTEND_URL", "http://localhost:5173"),
-		DeploymentMode: getEnv("DEPLOYMENT_MODE", "self-hosted"),
+		FrontendURL:    frontendURL,
+		PublicURL:      publicURL,
+		DeploymentMode: mode,
 	}
 }
 

--- a/backend/internal/handler/email.go
+++ b/backend/internal/handler/email.go
@@ -286,8 +286,9 @@ func (h *EmailHandler) Stats(w http.ResponseWriter, r *http.Request) {
 func (h *EmailHandler) Unsubscribe(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
 	subscriberID := r.PathValue("subscriberId")
+	token := r.URL.Query().Get("t")
 
-	err := h.emailService.Unsubscribe(r.Context(), projectID, subscriberID)
+	err := h.emailService.Unsubscribe(r.Context(), projectID, subscriberID, token)
 	if err != nil {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.WriteHeader(http.StatusNotFound)

--- a/backend/internal/handler/setup.go
+++ b/backend/internal/handler/setup.go
@@ -67,7 +67,7 @@ func (h *SetupHandler) Setup(w http.ResponseWriter, r *http.Request) {
 	tokens, err := h.authService.Register(r.Context(), req.Email, req.Password, req.Name)
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(errorResponse{Error: err.Error()})
 		return
 	}

--- a/backend/internal/handler/setup.go
+++ b/backend/internal/handler/setup.go
@@ -30,6 +30,7 @@ func (h *SetupHandler) Status(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]interface{}{
 		"setup_required":  count == 0,
 		"deployment_mode": h.cfg.DeploymentMode,
+		"public_url":      h.cfg.PublicURL,
 	})
 }
 

--- a/backend/internal/service/auth.go
+++ b/backend/internal/service/auth.go
@@ -8,12 +8,40 @@ import (
 	"encoding/hex"
 	"errors"
 	"time"
+	"unicode"
 
 	"github.com/arkhe-systems/senddock/internal/db"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
 )
+
+func ValidatePassword(password string) error {
+	if len(password) < 12 {
+		return errors.New("password must be at least 12 characters")
+	}
+	var hasLetter, hasDigit bool
+	unique := map[rune]struct{}{}
+	for _, r := range password {
+		unique[r] = struct{}{}
+		switch {
+		case unicode.IsLetter(r):
+			hasLetter = true
+		case unicode.IsDigit(r):
+			hasDigit = true
+		}
+	}
+	if !hasLetter {
+		return errors.New("password must contain at least one letter")
+	}
+	if !hasDigit {
+		return errors.New("password must contain at least one number")
+	}
+	if len(unique) < 6 {
+		return errors.New("password is too repetitive")
+	}
+	return nil
+}
 
 type AuthTokens struct {
 	AccessToken  string
@@ -32,6 +60,10 @@ func NewAuthService(queries *db.Queries, jwtSecret string) *AuthService {
 }
 
 func (s *AuthService) Register(ctx context.Context, email, password, name string) (AuthTokens, error) {
+	if err := ValidatePassword(password); err != nil {
+		return AuthTokens{}, err
+	}
+
 	_, err := s.queries.GetUserByEmail(ctx, email)
 	if err == nil {
 		return AuthTokens{}, errors.New("email already registered")

--- a/backend/internal/service/email.go
+++ b/backend/internal/service/email.go
@@ -2,8 +2,11 @@ package service
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
 	"crypto/tls"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -21,13 +24,28 @@ import (
 
 type EmailService struct {
 	queries   *db.Queries
-	baseURL   string
+	publicURL string
 	encSecret string
 	cache     *cache.Redis
 }
 
-func NewEmailService(queries *db.Queries, baseURL, encSecret string, redis *cache.Redis) *EmailService {
-	return &EmailService{queries: queries, baseURL: baseURL, encSecret: encSecret, cache: redis}
+func NewEmailService(queries *db.Queries, publicURL, encSecret string, redis *cache.Redis) *EmailService {
+	return &EmailService{queries: queries, publicURL: publicURL, encSecret: encSecret, cache: redis}
+}
+
+func (s *EmailService) signUnsub(projectID, subscriberID string) string {
+	mac := hmac.New(sha256.New, []byte(s.encSecret))
+	mac.Write([]byte(projectID + ":" + subscriberID))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func (s *EmailService) verifyUnsubToken(projectID, subscriberID, token string) bool {
+	expected := s.signUnsub(projectID, subscriberID)
+	return hmac.Equal([]byte(expected), []byte(token))
+}
+
+func (s *EmailService) unsubURL(projectID, subscriberID string) string {
+	return fmt.Sprintf("%s/unsubscribe/%s/%s?t=%s", s.publicURL, projectID, subscriberID, s.signUnsub(projectID, subscriberID))
 }
 
 type SendResult struct {
@@ -77,8 +95,7 @@ func (s *EmailService) SendToSubscriber(ctx context.Context, projectID, subscrib
 	body := replaceVariables(template.HtmlBody, sub)
 	subject := replaceVariablesSimple(template.Subject, sub)
 
-	unsubURL := fmt.Sprintf("%s/unsubscribe/%s/%s", s.baseURL, pid.String(), sid.String())
-	body = strings.ReplaceAll(body, "{{unsubscribe_url}}", unsubURL)
+	body = strings.ReplaceAll(body, "{{unsubscribe_url}}", s.unsubURL(pid.String(), sid.String()))
 
 	logID := s.logEmail(ctx, pid, uuid.NullUUID{UUID: sid, Valid: true}, uuid.NullUUID{UUID: tid, Valid: true}, sub.Email, subject, nil)
 	body = s.injectTrackingPixel(body, logID)
@@ -146,8 +163,7 @@ func (s *EmailService) Broadcast(ctx context.Context, projectID, templateID stri
 			body = replaceVariables(body, sub)
 			subject = replaceVariablesSimple(subject, sub)
 
-			unsubURL := fmt.Sprintf("%s/unsubscribe/%s/%s", s.baseURL, pid.String(), sub.ID.String())
-			body = strings.ReplaceAll(body, "{{unsubscribe_url}}", unsubURL)
+			body = strings.ReplaceAll(body, "{{unsubscribe_url}}", s.unsubURL(pid.String(), sub.ID.String()))
 
 			sendErr := s.sendSMTP(project, sub.Email, subject, body)
 			s.logEmail(bgCtx, pid, uuid.NullUUID{UUID: sub.ID, Valid: true}, uuid.NullUUID{UUID: tid, Valid: true}, sub.Email, subject, sendErr)
@@ -327,14 +343,18 @@ func (s *EmailService) logEmail(ctx context.Context, projectID uuid.UUID, subscr
 }
 
 func (s *EmailService) injectTrackingPixel(body string, logID uuid.UUID) string {
-	pixel := fmt.Sprintf(`<img src="%s/t/%s.gif" width="1" height="1" style="display:none" />`, s.baseURL, logID.String())
+	pixel := fmt.Sprintf(`<img src="%s/t/%s.gif" width="1" height="1" style="display:none" />`, s.publicURL, logID.String())
 	if strings.Contains(body, "</body>") {
 		return strings.Replace(body, "</body>", pixel+"</body>", 1)
 	}
 	return body + pixel
 }
 
-func (s *EmailService) Unsubscribe(ctx context.Context, projectID, subscriberID string) error {
+func (s *EmailService) Unsubscribe(ctx context.Context, projectID, subscriberID, token string) error {
+	if !s.verifyUnsubToken(projectID, subscriberID, token) {
+		return errors.New("invalid token")
+	}
+
 	sid, err := uuid.Parse(subscriberID)
 	if err != nil {
 		return errors.New("invalid subscriber id")

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
             { text: 'Installation', link: '/self-hosting/installation' },
             { text: 'Configuration', link: '/self-hosting/configuration' },
             { text: 'Updating', link: '/self-hosting/updating' },
+            { text: 'Troubleshooting & FAQ', link: '/self-hosting/troubleshooting' },
           ],
         },
       ],

--- a/docs/guide/environment.md
+++ b/docs/guide/environment.md
@@ -16,7 +16,17 @@ All configuration is done via environment variables. Copy `.env.example` to `.en
 | `PORT` | HTTP server port | `8080` |
 | `REDIS_URL` | Redis connection string | — |
 | `FRONTEND_URL` | Frontend URL for CORS headers | `http://localhost:5173` |
+| `PUBLIC_URL` | Public URL of this instance, used to build unsubscribe and tracking links inside outgoing emails. Leave blank in single-binary deploys to fall back to `FRONTEND_URL`. | _falls back to `FRONTEND_URL`_ |
 | `DEPLOYMENT_MODE` | `self-hosted` or `cloud` | `self-hosted` |
+
+::: tip Why PUBLIC_URL?
+Outgoing emails contain links like the unsubscribe URL and the open-tracking pixel. SendDock cannot guess what URL recipients will see — it has to be told. In most single-binary deploys (Go binary serves both the API and the SPA), `PUBLIC_URL` and `FRONTEND_URL` are the same value, so you can leave `PUBLIC_URL` blank and only set `FRONTEND_URL`.
+
+Set `PUBLIC_URL` explicitly when:
+- Your backend is on a different domain/subdomain than the frontend SPA.
+- You're behind a reverse proxy that terminates TLS.
+- You want unsubscribe links to point at a different domain than the dashboard.
+:::
 
 ## Deployment Modes
 
@@ -39,6 +49,7 @@ DATABASE_URL=postgres://senddock:senddock_dev@localhost:5434/senddock?sslmode=di
 JWT_SECRET=change-this-to-a-random-secret
 PORT=8080
 REDIS_URL=redis://localhost:6380
-FRONTEND_URL=http://localhost:5173
+FRONTEND_URL=https://email.mycompany.com
+PUBLIC_URL=https://email.mycompany.com
 DEPLOYMENT_MODE=self-hosted
 ```

--- a/docs/self-hosting/configuration.md
+++ b/docs/self-hosting/configuration.md
@@ -35,12 +35,14 @@ Redis is used for job queues and caching (planned features). Port `6380` by defa
 
 Before exposing to the internet:
 
-- [ ] Change `JWT_SECRET` to a random string (min 32 characters)
+- [ ] Change `JWT_SECRET` to a random string (min 32 characters): `openssl rand -base64 48`
 - [ ] Change PostgreSQL password from default
-- [ ] Set `FRONTEND_URL` to your actual domain
-- [ ] Use HTTPS via reverse proxy
-- [ ] Set cookie `Secure: true` in production (requires code change)
+- [ ] Set `FRONTEND_URL` to your actual domain (used for CORS)
+- [ ] Set `PUBLIC_URL` to the same domain (used for unsubscribe + tracking links inside emails)
+- [ ] Use HTTPS via reverse proxy — `Secure` cookies are set automatically when `FRONTEND_URL` starts with `https://`
 - [ ] Keep SendDock updated
+
+If anything misbehaves after going live, see [Troubleshooting](/self-hosting/troubleshooting).
 
 ## Ports
 

--- a/docs/self-hosting/troubleshooting.md
+++ b/docs/self-hosting/troubleshooting.md
@@ -1,0 +1,191 @@
+# Troubleshooting & FAQ
+
+Common problems you might run into when self-hosting SendDock, and how to fix them.
+
+## Outgoing emails
+
+### Unsubscribe links don't work / land on a 404
+
+**Symptom:** Recipients click the unsubscribe link inside an email and get a 404 or a "Link expired or invalid" page.
+
+**Cause:** Your `PUBLIC_URL` is wrong (often still `http://localhost:8080`), or the request never reaches the backend because your reverse proxy is routing only `/api/*`.
+
+**Fix:**
+
+1. Open the dashboard → any project → **Settings** → check the "Instance URL" panel. The URL shown there is what every email will use.
+2. Set `PUBLIC_URL` in your `.env` to the public domain where SendDock is reachable, e.g. `PUBLIC_URL=https://email.mycompany.com`.
+3. Make sure your reverse proxy forwards `/unsubscribe/*` and `/t/*` (open-tracking pixel) to the backend, not just `/api/*`. With the single-binary deploy, both routes are served by the Go process on the same port as the API.
+4. Restart the backend so the new value takes effect.
+
+If you migrated from an older version, links generated **before** you set `PUBLIC_URL` are signed against whatever URL/secret was active then — they will fail validation. New emails will work.
+
+### Tracking pixel never registers opens
+
+Same root cause as above. The pixel is `GET /t/{logId}.gif` on the backend. If your reverse proxy only forwards `/api/*`, the pixel returns 404 and opens never get marked.
+
+### "Sender address rejected" / SMTP authentication failed
+
+**Cause:** The SMTP `From` address you configured doesn't match the authenticated user, or your provider requires SPF/DKIM alignment.
+
+**Fix:** In **Project → SMTP**, set the **From Email** field to an address on a domain you own and have authorized. Most providers (SES, Mailgun, Postmark) reject sends from unverified domains.
+
+### TLS certificate errors (`x509: certificate has expired`)
+
+**Cause:** Your SMTP server is presenting an expired or self-signed certificate. This is common with self-hosted Poste.io, Mailcow, or Mail-in-a-Box instances when the Let's Encrypt cert hasn't auto-renewed.
+
+**Fix options (in order of preference):**
+
+1. **Renew the certificate** on your mail server. This is the right fix.
+2. **Switch port:** if you're on `465` (implicit TLS) and getting handshake errors, try `587` (STARTTLS) or vice-versa. SendDock auto-detects from the port.
+3. **Last resort:** SendDock currently skips strict certificate validation for outgoing SMTP connections so a flaky cert doesn't block your sends. Mail still goes out over TLS, you just don't get man-in-the-middle protection. Renew the cert ASAP.
+
+### `connection refused` when sending
+
+**Cause:** Wrong host/port, or the mail server is firewalled.
+
+**Fix:** From the SendDock host, confirm you can reach the SMTP server: `nc -vz smtp.example.com 587`. If that fails, the problem is your network/firewall, not SendDock. Cloud providers often block port 25 — use 587 or 465 with auth.
+
+## Authentication & cookies
+
+### "missing access token" on every request after deploy
+
+**Cause:** Your frontend is on HTTPS but cookies are being set without `Secure: true`, so the browser drops them.
+
+**Fix:** Ensure your `FRONTEND_URL` env starts with `https://` in production. SendDock detects this and sets `Secure: true` on auth cookies automatically. If you reverse-proxy TLS, also make sure the proxy forwards the `X-Forwarded-Proto` header.
+
+### Login works but the next request fails / "401 unauthorized"
+
+**Cause:** Backend and frontend are on different origins and CORS isn't configured to send credentials.
+
+**Fix:** Set `FRONTEND_URL` to the exact origin of your dashboard, e.g. `https://email.mycompany.com` (no trailing slash, scheme included). The CORS middleware uses this to set `Access-Control-Allow-Origin` and `Access-Control-Allow-Credentials: true`.
+
+### `JWT_SECRET must be at least 32 characters` panic at startup
+
+**Cause:** The placeholder secret was kept, or a weak secret was set.
+
+**Fix:** Generate a strong random secret:
+
+```bash
+openssl rand -base64 48
+```
+
+Paste it into `JWT_SECRET` in `.env` and restart.
+
+## Networking & deploys
+
+### Container starts but I can't reach it on the public domain
+
+**Cause:** No reverse proxy is forwarding traffic to the SendDock container, or the proxy only forwards `/api/*`.
+
+**Fix:** SendDock is a single binary that serves both the API and the SPA on one port. Forward **everything** for your domain to the backend port (default `8080`). Example Caddy:
+
+```caddy
+email.mycompany.com {
+    reverse_proxy senddock:8080
+}
+```
+
+### Frontend hits `localhost:8080` in production
+
+**Cause:** The frontend was built without `VITE_API_URL` set, so it baked in the dev default.
+
+**Fix:** Either rebuild with `VITE_API_URL=/api/v1` (recommended for single-binary deploys), or set it to your full backend URL like `VITE_API_URL=https://email.mycompany.com/api/v1`.
+
+### Browser shows CORS error on the public waitlist endpoint
+
+**Cause:** You're embedding the waitlist form on a different domain than your SendDock instance.
+
+**Fix:** This is intentional for the public waitlist endpoint — it explicitly sets `Access-Control-Allow-Origin: *` so you can embed the form anywhere. If you're getting a CORS error on this endpoint, double-check that you're hitting `POST /api/v1/projects/{id}/waitlist` (not the protected `/subscribers` endpoint).
+
+## Database & migrations
+
+### "relation does not exist" errors after upgrade
+
+**Cause:** Pending migrations weren't applied.
+
+**Fix:**
+
+```bash
+cd backend && make migrate
+```
+
+Or, if running via Docker, exec into the backend container and run the same command.
+
+### Container crashes on startup with `pq: SSL is not enabled on the server`
+
+**Cause:** Your `DATABASE_URL` has `sslmode=require` but the Postgres instance isn't configured for TLS.
+
+**Fix:** For local Postgres, use `?sslmode=disable`. For managed Postgres (Supabase, RDS, Neon), use `?sslmode=require`.
+
+## Setup script (`setup.sh` / `setup.ps1`)
+
+### `setup.ps1` blocked on Windows: "is not digitally signed"
+
+**Symptom:** Running `.\setup.ps1` produces:
+
+```
+.\setup.ps1 cannot be loaded. The file is not digitally signed.
+```
+
+**Cause:** Default Windows execution policy blocks unsigned PowerShell scripts. SendDock's `setup.ps1` is plain text, not signed by a certificate.
+
+**Fix:** Allow scripts **for the current session only** — no permanent security change, the bypass reverts when you close the window:
+
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+.\setup.ps1
+```
+
+### "`.env` already exists. Delete it first if you want to re-run setup"
+
+**Cause:** A previous run of `setup.ps1` / `setup.sh` got far enough to create the `.env` file but failed before finishing (usually because the Docker daemon wasn't ready yet, or an image pull errored). The script refuses to overwrite your `.env` so it doesn't clobber a working config.
+
+**Fix:** Clean the partial state and re-run:
+
+```bash
+# Linux / macOS
+rm .env
+docker compose -f docker-compose.prod.yml down -v
+./setup.sh
+```
+
+```powershell
+# Windows
+Remove-Item .env
+docker compose -f docker-compose.prod.yml down -v
+.\setup.ps1
+```
+
+The `down -v` flag also removes the Postgres and Redis volumes — important so the next run doesn't try to run migrations against a half-initialized database.
+
+### `setup.ps1` prints "SendDock is running" but `localhost:8080` refuses the connection
+
+**Cause:** The script reports success based on the file generation steps, not on whether `docker compose up` actually brought the containers online. If an image pull fails partway through, you'll see the green "running" message but no container is actually serving on 8080.
+
+**Fix:** Check what's actually up:
+
+```bash
+docker compose -f docker-compose.prod.yml ps
+docker compose -f docker-compose.prod.yml logs app
+```
+
+If `app` isn't listed or is restarting, scroll up in the `setup.ps1` / `setup.sh` output for the real error (commonly a Docker pull failure or a migration error). Once you've fixed the underlying issue, follow the cleanup steps from the previous section and re-run setup.
+
+## Redis
+
+### Do I need Redis?
+
+No — Redis is **optional**. It's used for caching email stats and rate-limiting. SendDock works without it; you'll just see slightly slower stats endpoints under heavy load. Leave `REDIS_URL` blank to disable.
+
+### "redis: connection refused"
+
+If you set `REDIS_URL` but Redis is unreachable, SendDock falls back to direct database queries. The error in the logs is harmless — but if you intended Redis to be enabled, check the connection string and that the container is running.
+
+## Asking for help
+
+If your issue isn't here, open an issue on [GitHub](https://github.com/arkhe-systems/senddock/issues) with:
+
+- SendDock version (`docker logs senddock | grep version` or check the bottom of the dashboard)
+- Deployment mode (`self-hosted` / `cloud`)
+- Relevant logs (redact secrets)
+- Steps to reproduce

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -7,6 +7,7 @@ import { api } from '@/api/client'
 interface SetupStatus {
   setup_required: boolean
   deployment_mode: string
+  public_url: string
 }
 
 const router = createRouter({
@@ -90,6 +91,7 @@ router.beforeEach(async (to) => {
       const status = await api<SetupStatus>('/setup/status')
       app.setupRequired = status.setup_required
       app.deploymentMode = status.deployment_mode
+      app.publicUrl = status.public_url || ''
     } catch {
       app.setupRequired = false
     }

--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -4,7 +4,8 @@ import { ref } from 'vue'
 export const useAppStore = defineStore('app', () => {
     const deploymentMode = ref('self-hosted')
     const setupRequired = ref(false)
+    const publicUrl = ref('')
     const checked = ref(false)
 
-    return { deploymentMode, setupRequired, checked }
+    return { deploymentMode, setupRequired, publicUrl, checked }
 })

--- a/frontend/src/views/project/SettingsSection.vue
+++ b/frontend/src/views/project/SettingsSection.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { api } from '@/api/client'
 import { useToastStore } from '@/stores/toast'
+import { useAppStore } from '@/stores/app'
 import type { Project } from '@/stores/projects'
 import AppInput from '@/components/ui/AppInput.vue'
 import AppButton from '@/components/ui/AppButton.vue'
@@ -26,6 +27,15 @@ const emit = defineEmits<{ updated: [] }>()
 
 const router = useRouter()
 const toast = useToastStore()
+const appStore = useAppStore()
+
+const instanceUrl = computed(() => appStore.publicUrl || window.location.origin)
+const isLocalhost = computed(() => instanceUrl.value.startsWith('http://localhost'))
+
+async function copyInstanceUrl() {
+    await navigator.clipboard.writeText(instanceUrl.value)
+    toast.success('Instance URL copied')
+}
 
 const projectName = ref('')
 const projectDescription = ref('')
@@ -161,6 +171,23 @@ async function handleDelete() {
                     </AppButton>
                 </div>
             </form>
+        </div>
+
+        <div class="bg-zinc-900 border border-zinc-800 rounded-lg p-6 max-w-lg">
+            <h2 class="text-sm font-medium text-white mb-2">Instance URL</h2>
+            <p class="text-xs text-zinc-500 mb-4">
+                Public URL used to build unsubscribe links and tracking pixels in outgoing emails. Set <code class="text-zinc-400">PUBLIC_URL</code> in your environment to change it.
+            </p>
+            <div class="flex items-center gap-2">
+                <code class="flex-1 px-3 py-2 bg-zinc-950 border border-zinc-800 rounded-lg text-xs text-white break-all">{{ instanceUrl }}</code>
+                <button type="button" @click="copyInstanceUrl"
+                    class="px-3 py-2 text-xs bg-zinc-800 hover:bg-zinc-700 text-white rounded-lg transition cursor-pointer">
+                    Copy
+                </button>
+            </div>
+            <p v-if="isLocalhost" class="text-xs text-yellow-400 mt-3">
+                Heads up: this URL points to localhost. Unsubscribe links and tracking pixels in outgoing emails won't work outside this machine. Set <code>PUBLIC_URL</code> to your public domain in production.
+            </p>
         </div>
 
         <div class="bg-zinc-900 border border-zinc-800 rounded-lg p-6 max-w-lg">

--- a/frontend/src/views/setup/SetupView.vue
+++ b/frontend/src/views/setup/SetupView.vue
@@ -1,20 +1,48 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { api } from '@/api/client'
 import { useAuthStore } from '@/stores/auth'
+import { useAppStore } from '@/stores/app'
+import { useToastStore } from '@/stores/toast'
 import AppInput from '@/components/ui/AppInput.vue'
 import AppButton from '@/components/ui/AppButton.vue'
 import AppAlert from '@/components/ui/AppAlert.vue'
 
 const router = useRouter()
 const auth = useAuthStore()
+const app = useAppStore()
+const toast = useToastStore()
 
 const name = ref('')
 const email = ref('')
 const password = ref('')
+const passwordConfirm = ref('')
 const error = ref('')
 const loading = ref(false)
+
+function validatePassword(pw: string): string | null {
+    if (pw.length < 12) return 'Password must be at least 12 characters'
+    if (!/[a-zA-Z]/.test(pw)) return 'Password must contain at least one letter'
+    if (!/[0-9]/.test(pw)) return 'Password must contain at least one number'
+    if (new Set(pw).size < 6) return 'Password is too repetitive'
+    return null
+}
+
+const passwordStrength = computed(() => {
+    const pw = password.value
+    if (!pw) return { label: '', color: '', width: 0 }
+    let score = 0
+    if (pw.length >= 12) score++
+    if (pw.length >= 16) score++
+    if (/[a-z]/.test(pw) && /[A-Z]/.test(pw)) score++
+    if (/[0-9]/.test(pw)) score++
+    if (/[^a-zA-Z0-9]/.test(pw)) score++
+    if (score <= 1) return { label: 'Weak', color: 'bg-red-500 text-red-400', width: 25 }
+    if (score === 2) return { label: 'Fair', color: 'bg-yellow-500 text-yellow-400', width: 50 }
+    if (score === 3) return { label: 'Good', color: 'bg-blue-500 text-blue-400', width: 75 }
+    return { label: 'Strong', color: 'bg-green-500 text-green-400', width: 100 }
+})
 
 async function handleSetup() {
     error.value = ''
@@ -24,8 +52,14 @@ async function handleSetup() {
         return
     }
 
-    if (password.value.length < 8) {
-        error.value = 'Password must be at least 8 characters'
+    const pwErr = validatePassword(password.value)
+    if (pwErr) {
+        error.value = pwErr
+        return
+    }
+
+    if (password.value !== passwordConfirm.value) {
+        error.value = 'Passwords do not match'
         return
     }
 
@@ -36,6 +70,8 @@ async function handleSetup() {
             body: { name: name.value, email: email.value, password: password.value },
         })
         auth.isAuthenticated = true
+        app.setupRequired = false
+        toast.success('Welcome to SendDock! Your admin account is ready.')
         router.push('/dashboard')
     } catch (e: any) {
         error.value = e.message || 'Setup failed'
@@ -73,7 +109,18 @@ async function handleSetup() {
                 <AppAlert :message="error" />
                 <AppInput v-model="name" label="Full Name" placeholder="John Doe" required />
                 <AppInput v-model="email" label="Email" type="email" placeholder="admin@example.com" required />
-                <AppInput v-model="password" label="Password" type="password" placeholder="Minimum 8 characters" required />
+                <div>
+                    <AppInput v-model="password" label="Password" type="password" placeholder="At least 12 characters" required />
+                    <div v-if="password" class="mt-2">
+                        <div class="flex items-center justify-between mb-1">
+                            <span class="text-xs" :class="passwordStrength.color.split(' ')[1]">{{ passwordStrength.label }}</span>
+                        </div>
+                        <div class="h-1 bg-zinc-800 rounded-full overflow-hidden">
+                            <div class="h-full transition-all" :class="passwordStrength.color.split(' ')[0]" :style="{ width: passwordStrength.width + '%' }"></div>
+                        </div>
+                    </div>
+                </div>
+                <AppInput v-model="passwordConfirm" label="Confirm Password" type="password" placeholder="Repeat your password" required />
                 <AppButton :loading="loading">
                     {{ loading ? 'Setting up...' : 'Complete Setup' }}
                 </AppButton>


### PR DESCRIPTION
# v0.4 launch prep: PUBLIC_URL, signed unsubscribe, setup polish, troubleshooting docs

## Summary

Pre-launch hardening of the self-host experience ahead of v0.4. Splits the public URL out of `FRONTEND_URL`, signs unsubscribe URLs with HMAC, tightens the first-run setup flow, and documents the recovery paths for the issues hit during the Windows / Docker Desktop dry-run.

## Why

While doing a clean self-host install on Windows 11 / Docker Desktop we hit a handful of friction points that would bite real users:

- Unsubscribe and tracking-pixel URLs were built from `FRONTEND_URL`, conflating "where the SPA lives for CORS purposes" with "what URL recipients see in their inbox". These need to be configurable independently.
- Unsubscribe URLs were unsigned, so anyone who knew the project and subscriber UUIDs could mark a subscriber as unsubscribed.
- The setup screen accepted `12345678` as a valid admin password.
- After completing setup, the user was not redirected to the dashboard; pressing the button a second time showed `setup already completed`.
- Several recovery paths (partial `setup.ps1` runs, reverse-proxy routing for `/unsubscribe`, SMTP TLS edge cases) had no documentation.

## Changes

### `feat(emails)`: PUBLIC_URL config and HMAC-signed unsubscribe links

- New `PUBLIC_URL` env var, used to build unsubscribe and tracking-pixel URLs in outgoing emails. Falls back to `FRONTEND_URL` when unset, so existing single-binary deploys do not need any change.
- Startup warning when `PUBLIC_URL` resolves to localhost in self-hosted mode.
- Unsubscribe URLs now carry an HMAC token derived from project id, subscriber id and `JWT_SECRET`, validated server-side. UUID enumeration is no longer enough to unsubscribe a recipient.
- Tracking pixel uses the same `PUBLIC_URL`.

### `feat(settings)`: expose Instance URL in project settings

- `/setup/status` returns `public_url`.
- App store carries `publicUrl`, populated on first request.
- New Instance URL panel in project Settings shows the configured value with a copy button, plus an inline warning when it still points at localhost.

### `feat(setup)`: enforce strong passwords and fix post-setup redirect

- Shared `ValidatePassword` in the service layer requires minimum 12 characters, at least one letter, at least one number, and at least 6 unique characters. Called from `AuthService.Register`, covering both `/setup` and `/auth/register`.
- Setup handler now returns 400 on validation errors instead of 500.
- Setup view gains a confirm-password field, a four-tier strength meter, and matching client-side validation.
- After a successful setup, the app store flips `setupRequired` to false so the dashboard navigation is not bounced back by the router guard.
- Welcome toast shown after setup completes.

### `docs`: troubleshooting guide and PUBLIC_URL reference

- New `self-hosting/troubleshooting.md` covering:
  - PUBLIC_URL setup and reverse-proxy routing for `/unsubscribe` and `/t/`
  - SMTP TLS issues (expired certs, port 465 vs 587, `connection refused`)
  - Cookie `Secure` flag behind HTTPS
  - CORS for cross-origin frontends
  - Weak `JWT_SECRET`
  - Partial `setup.ps1` / `setup.sh` recovery
  - Database SSL mode mismatches
  - Optional Redis behavior
- Environment reference documents `PUBLIC_URL` with a tip explaining when it differs from `FRONTEND_URL`.
- Configuration security checklist updated.

## Backwards compatibility

- `PUBLIC_URL` defaults to `FRONTEND_URL` when unset, so existing deploys keep working with no env change.
- HMAC verification on unsubscribe is strict. Links generated by previous versions (without a token) will fail validation. Acceptable since there are no production users yet.
- Stronger password rules apply only to new account creation; existing accounts are not affected.

## Test plan

- [ ] `go build ./...` and `go vet ./...` are clean.
- [ ] `vue-tsc --noEmit` is clean.
- [ ] Run `setup.ps1` / `setup.sh` on a fresh database:
  - [ ] Weak password (`12345678`) is rejected with a 400 and a descriptive error.
  - [ ] Confirm-password mismatch is caught client-side.
  - [ ] Successful setup redirects to the dashboard without bouncing back.
  - [ ] Welcome toast is shown.
- [ ] Project Settings shows the Instance URL panel with the configured `PUBLIC_URL`. Localhost warning appears when applicable.
- [ ] Send a broadcast to a test subscriber, click the unsubscribe link, confirm the page reads "You have been unsubscribed".
- [ ] Manually tamper with the `?t=` token in the unsubscribe URL and confirm the link returns "Link expired or invalid".
- [ ] Open-tracking pixel still registers an open after `PUBLIC_URL` is set.

## Commits

- `7038a9e` feat(emails): add PUBLIC_URL config and HMAC-signed unsubscribe links
- `c68d4df` feat(settings): expose instance URL in project settings
- `0e5af97` feat(setup): enforce strong passwords and fix post-setup redirect
- `679dddc` docs: add troubleshooting guide and document PUBLIC_URL
