### PR TITLE
fix(emails): replace unsubscribe placeholder on /send when recipient …

### DIFF
--- a/backend/internal/service/email.go
+++ b/backend/internal/service/email.go
@@ -275,7 +275,19 @@ func (s *EmailService) SendWithTemplate(ctx context.Context, projectID, template
 		subject = strings.ReplaceAll(subject, "{{"+key+"}}", val)
 	}
 
-	sendErr := s.sendSMTP(project, to, subject, body, "")
+	var unsubscribeURL string
+	if strings.Contains(body, "{{unsubscribe_url}}") {
+		sub, err := s.queries.GetSubscriberByEmail(ctx, db.GetSubscriberByEmailParams{Email: to, ProjectID: pid})
+		if err == nil {
+			unsubscribeURL = s.unsubURL(pid.String(), sub.ID.String())
+			body = strings.ReplaceAll(body, "{{name}}", html.EscapeString(sub.Name))
+			body = strings.ReplaceAll(body, "{{email}}", html.EscapeString(sub.Email))
+			body = strings.ReplaceAll(body, "{{subscriber_id}}", sub.ID.String())
+		}
+		body = strings.ReplaceAll(body, "{{unsubscribe_url}}", unsubscribeURL)
+	}
+
+	sendErr := s.sendSMTP(project, to, subject, body, unsubscribeURL)
 
 	s.logEmail(ctx, pid, uuid.NullUUID{}, uuid.NullUUID{UUID: tid, Valid: true}, to, subject, sendErr)
 


### PR DESCRIPTION
# fix(emails): replace `{{unsubscribe_url}}` on `/send` when recipient is a subscriber

## Summary

Hotfix on top of v0.4: `/send` with a `to` email field was leaving `{{unsubscribe_url}}` literal in the outgoing message body. Newsletter test sends from the "Specific email" mode in the dashboard would arrive with the placeholder visible instead of a clickable link.

## What was happening

The `/send` endpoint has three internal paths depending on the request body:

| Request body | Internal service | Replaced `{{unsubscribe_url}}`? |
|---|---|---|
| `subscriber_id` + `template_id` | `SendToSubscriber` | yes |
| `to` + `template_id` | `SendWithTemplate` | **no — bug** |
| `to` + `html_body` | `SendDirect` | n/a (no template) |

`SendWithTemplate` was originally designed for transactional templates (welcome, password reset, contact form) that do not contain `{{unsubscribe_url}}`. The placeholder fell through unreplaced. The flow worked for subscriber sends and broadcasts because those go through different functions.

The visible symptom: an admin tests their newsletter template by clicking "Send Email → Specific email" with their own address. The email arrives with `<a href="{{unsubscribe_url}}">Unsubscribe</a>` literal, which most clients render as plain text — the link is not clickable.

## Fix

In `SendWithTemplate`, when the template body contains `{{unsubscribe_url}}`:

1. Look up the recipient in the project's subscribers table by email.
2. If found, build the signed unsubscribe URL for that subscriber and replace the placeholder. Also replace `{{name}}`, `{{email}}`, `{{subscriber_id}}` so the email looks like a real broadcast send.
3. If not found, replace `{{unsubscribe_url}}` with an empty string. Better than shipping the raw placeholder; transactional sends still go through cleanly.
4. Pass the resolved URL to `sendSMTP` so the `List-Unsubscribe` header is included when applicable.

`SendToSubscriber`, `Broadcast`, and the campaign worker continue to work as before — they already handled this correctly.

## Backwards compatibility

- Pure transactional sends (template without `{{unsubscribe_url}}`) are unchanged.
- `/send` calls that already targeted real subscribers see their template variables resolved (previously left raw). This matches the documented behavior.
- No schema, env or API contract changes.

## Test plan

- [x] `go build ./...` and `go vet ./...` are clean.
- [x] `go test ./...` is green.
- [ ] Send a template containing `{{unsubscribe_url}}` to a subscriber's email via `/send` (Specific email mode in the dashboard). Verify:
  - [ ] The email's `href` is `https://<PUBLIC_URL>/unsubscribe/{pid}/{sid}?t=...`
  - [ ] The unsubscribe link is clickable
  - [ ] Clicking it lands on the "You have been unsubscribed" page
  - [ ] The email has a `List-Unsubscribe` header (visible in Gmail "Show original")
- [ ] Send the same template via `/send` to an email that is **not** in the subscribers table. Verify the placeholder is replaced with empty string (no `{{...}}` visible in the rendered email).
- [ ] Existing broadcast and subscriber-id flows still work.

## Commit

```
09fb874 fix(emails): replace unsubscribe placeholder on /send when recipient is a subscriber
```
