### PR TITLE
fix(modal): replace tiny x with proper close button and remove backdr…

### DIFF
--- a/frontend/src/components/ui/AppModal.vue
+++ b/frontend/src/components/ui/AppModal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
+import { onMounted, onUnmounted, watch } from 'vue'
 
-defineProps<{
+const props = defineProps<{
     title?: string,
     show?: boolean
 }>()
@@ -8,15 +9,34 @@ defineProps<{
 const emit = defineEmits<{
     close: []
 }>()
+
+function onKey(e: KeyboardEvent) {
+    if (e.key === 'Escape' && props.show) emit('close')
+}
+
+onMounted(() => window.addEventListener('keydown', onKey))
+onUnmounted(() => window.removeEventListener('keydown', onKey))
+
+watch(() => props.show, (v) => {
+    document.body.style.overflow = v ? 'hidden' : ''
+})
 </script>
 <template>
-    <div v-if="show" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50" @click="emit('close')">
-        <div class="bg-zinc-900 rounded-lg p-6 w-full max-w-md" @click.stop>
-            <div class="flex items-center justify-between mb-4">
-                <h2 class="text-lg font-semibold text-white">{{ title }}</h2>
-                <button @click="emit('close')" class="text-zinc-400 hover:text-white">&times;</button>
+    <div v-if="show" class="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
+        <div class="bg-zinc-900 border border-zinc-800 rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] flex flex-col">
+            <div class="flex items-center justify-between px-6 py-4 border-b border-zinc-800">
+                <h2 class="text-base font-semibold text-white">{{ title }}</h2>
+                <button @click="emit('close')" type="button" aria-label="Close"
+                    class="w-8 h-8 flex items-center justify-center rounded-lg text-zinc-400 hover:text-white hover:bg-zinc-800 transition cursor-pointer">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+                        <line x1="18" y1="6" x2="6" y2="18"></line>
+                        <line x1="6" y1="6" x2="18" y2="18"></line>
+                    </svg>
+                </button>
             </div>
-            <slot />
+            <div class="px-6 py-5 overflow-y-auto">
+                <slot />
+            </div>
         </div>
     </div>
 </template>


### PR DESCRIPTION
…op click

The previous modal closed on any click on the dim backdrop and the close button was a 16px '&times;' character that disappeared into the header. Both are easy to misclick, especially on mobile where the backdrop is most of the screen.

The new modal:
- Closes only via the X button or the Escape key. Backdrop clicks no longer dismiss; the user has to make a deliberate choice.
- Renders the X as a 32px square button with an SVG cross icon, hover background, and an explicit aria-label.
- Adds a header divider and locks page scroll while open so background content does not bleed through visually.