### PR TITLE
Add prebuilt-image install path and docker-compose.image.yml

### DIFF
--- a/docker-compose.image.yml
+++ b/docker-compose.image.yml
@@ -1,0 +1,57 @@
+services:
+  senddock:
+    image: arkhe-systems/senddock:latest
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgres://senddock:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/senddock?sslmode=disable
+      REDIS_URL: redis://redis:6379
+      JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required (min 32 chars)}
+      PORT: 8080
+      PUBLIC_URL: ${PUBLIC_URL:?PUBLIC_URL is required, e.g. https://senddock.example.com}
+      FRONTEND_URL: ${PUBLIC_URL}
+      DEPLOYMENT_MODE: self-hosted
+      SENDDOCK_LICENSE_KEY: ${SENDDOCK_LICENSE_KEY:-}
+      SENDDOCK_LICENSE_ENDPOINT: ${SENDDOCK_LICENSE_ENDPOINT:-https://license.senddock.com/v1/validate}
+    ports:
+      - "${SENDDOCK_PORT:-8080}:8080"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8080/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+
+  postgres:
+    image: postgres:17
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: senddock
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_DB: senddock
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U senddock"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    volumes:
+      - redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  pgdata:
+  redisdata:

--- a/docker-compose.image.yml
+++ b/docker-compose.image.yml
@@ -1,6 +1,6 @@
 services:
   senddock:
-    image: arkhe-systems/senddock:latest
+    image: ghcr.io/arkhe-systems/senddock:latest
     restart: unless-stopped
     depends_on:
       postgres:

--- a/docs/self-hosting/installation.md
+++ b/docs/self-hosting/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-SendDock ships as a single Docker image: `arkhe-systems/senddock`. Three install paths are supported, in order of preference.
+SendDock ships as a single Docker image: `ghcr.io/arkhe-systems/senddock`. Three install paths are supported, in order of preference.
 
 ## Requirements
 
@@ -60,10 +60,10 @@ The image is the same in both cases. The license key, validated against a hosted
 ```yaml
 services:
   senddock:
-    image: arkhe-systems/senddock:0.4.0
+    image: ghcr.io/arkhe-systems/senddock:0.4.0
 ```
 
-See available tags on [Docker Hub](https://hub.docker.com/r/arkhe-systems/senddock/tags).
+See available tags on [GHCR](https://github.com/Arkhe-Systems/senddock/pkgs/container/senddock).
 
 ---
 

--- a/docs/self-hosting/installation.md
+++ b/docs/self-hosting/installation.md
@@ -1,5 +1,7 @@
 # Installation
 
+SendDock ships as a single Docker image: `arkhe-systems/senddock`. Three install paths are supported, in order of preference.
+
 ## Requirements
 
 - A Linux server (Ubuntu, Debian, etc.)
@@ -7,7 +9,75 @@
 
 That's it. Everything else is handled by Docker.
 
-## Quick Start
+---
+
+## Option 1: Prebuilt image (recommended)
+
+The fastest path. Pull the canonical image, point a `.env` at it, run.
+
+```bash
+mkdir senddock && cd senddock
+curl -fsSL https://raw.githubusercontent.com/arkhe-systems/senddock/main/docker-compose.image.yml -o docker-compose.yml
+```
+
+Create `.env` next to it:
+
+```bash
+cat > .env <<EOF
+POSTGRES_PASSWORD=$(openssl rand -base64 32)
+JWT_SECRET=$(openssl rand -hex 32)
+PUBLIC_URL=https://your-domain.com
+SENDDOCK_PORT=8080
+SENDDOCK_LICENSE_KEY=
+EOF
+```
+
+Replace `your-domain.com` with your real public hostname before running. `PUBLIC_URL` is required for unsubscribe and broadcast links to work.
+
+Then:
+
+```bash
+docker compose up -d
+```
+
+The container runs `goose up` against Postgres on first start, then serves on `:8080`. Healthcheck tells you when it's ready (~10 seconds cold).
+
+Open `http://your-domain.com` (or `http://localhost:8080` for a local test) and create your admin account on the setup screen.
+
+### What you get
+
+| `SENDDOCK_LICENSE_KEY` | Behavior |
+|---|---|
+| empty | Free tier — Core features (subscribers, templates, transactional sends, broadcasts, campaigns, BYO SMTP). |
+| valid | Pro tier — adds advanced analytics, audit logs, team roles, A/B testing. |
+
+The image is the same in both cases. The license key, validated against a hosted endpoint, toggles the gated routes. Read more in the [pricing page](https://senddock.com/pricing).
+
+### Pinning a version in production
+
+`:latest` is the default for first-time installs. For production, pin to a specific version so you control when updates land:
+
+```yaml
+services:
+  senddock:
+    image: arkhe-systems/senddock:0.4.0
+```
+
+See available tags on [Docker Hub](https://hub.docker.com/r/arkhe-systems/senddock/tags).
+
+---
+
+## Option 2: Dokploy (one-click)
+
+If you run [Dokploy](https://dokploy.com) on your server, SendDock is available in the templates marketplace. Open Dokploy → Templates → search for "SendDock" → Install. Dokploy renders the same `docker-compose.image.yml` shown above, prompts you for the env vars, and starts the stack.
+
+This is the recommended path if you already use Dokploy to manage other apps.
+
+---
+
+## Option 3: Build from source
+
+For self-hosters who want to compile Core from source — useful for audits, custom patches, or running an unreleased branch.
 
 ### Linux / macOS
 
@@ -27,13 +97,13 @@ cd senddock
 
 The setup script is **idempotent**:
 
-- **Fresh install**: generates secrets, creates `.env`, builds the image, starts services.
-- **Existing install**: keeps your `.env`, rebuilds the image with the current code, restarts services. This is the same script you use to update — `./setup.sh` after a `git pull` is the entire upgrade flow.
+- **Fresh install**: generates secrets, creates `.env`, builds the image from source, starts services.
+- **Existing install**: keeps your `.env`, rebuilds with the current code, restarts services. Same script you use to update — `./setup.sh` after `git pull` is the entire upgrade flow.
 - **Reset**: pass `--reset` (or `-Reset` on Windows) to wipe containers, volumes and `.env` before starting fresh. **This deletes all data**, so use it only on test instances.
 
-After running, the script waits for SendDock to be healthy and only then reports success. If startup fails it points at `docker compose logs app` so you can see the real error.
+After running, the script waits for SendDock to be healthy and only then reports success. If startup fails it points at `docker compose logs app`.
 
-Open `http://localhost:8080` and create your admin account.
+This path runs `docker-compose.prod.yml`, which builds the image locally instead of pulling the prebuilt one. The result is the same Core experience as Option 1 with `SENDDOCK_LICENSE_KEY` empty — Pro features are not present in source-built images.
 
 ### What gets started
 
@@ -43,38 +113,34 @@ Open `http://localhost:8080` and create your admin account.
 - Redis for caching
 - Database migrations run automatically
 
-## What's Running
+---
+
+## What's running
 
 | Service | Description |
 |---------|-------------|
-| `app` | SendDock (Go API + Vue frontend) on port 8080 |
-| `postgres` | PostgreSQL 17 database |
-| `redis` | Redis 7 for caching |
-| `migrate` | Runs migrations on startup, then stops |
+| `senddock` | The SendDock binary (Go API + Vue frontend) on port 8080 |
+| `postgres` | PostgreSQL 17 database (named volume `pgdata`) |
+| `redis` | Redis 7 for caching (named volume `redisdata`) |
 
-## Custom Port or Domain
+Migrations run inside the `senddock` container's entrypoint on every start, against the existing database. Goose deduplicates already-applied migrations, so restarts and updates never replay them.
 
-Edit `.env` (generated by `setup.sh`):
+---
 
-```bash
-FRONTEND_URL=https://your-domain.com
-```
+## Custom port or domain
 
-To change the port, edit `docker-compose.prod.yml`:
-
-```yaml
-app:
-  ports:
-    - "3000:8080"
-```
-
-Then restart:
+The `.env` you created controls both:
 
 ```bash
-docker compose -f docker-compose.prod.yml up -d
+PUBLIC_URL=https://your-domain.com
+SENDDOCK_PORT=8080
 ```
 
-## Reverse Proxy (HTTPS)
+`PUBLIC_URL` is required for unsubscribe links and broadcasts to work — without it the broadcast endpoint refuses to send.
+
+---
+
+## Reverse proxy (HTTPS)
 
 For production, put SendDock behind a reverse proxy with HTTPS.
 
@@ -106,34 +172,42 @@ server {
 }
 ```
 
-Update `FRONTEND_URL` in `.env` to `https://your-domain.com`.
+Set `PUBLIC_URL` in `.env` to `https://your-domain.com` and restart.
 
-## First-time Setup
+---
 
-1. Open your instance in a browser
-2. The setup screen appears automatically (no users exist yet)
-3. Create your admin account (name, email, password)
-4. You're logged in and ready to create your first project
+## First-time setup
+
+1. Open your instance in a browser.
+2. The setup screen appears automatically (no users exist yet).
+3. Create your admin account (name, email, password).
+4. You're logged in and ready to create your first project.
+
+---
 
 ## Stopping
 
 ```bash
-docker compose -f docker-compose.prod.yml down
+docker compose down
 ```
 
 To stop and remove all data (including database):
 
 ```bash
-docker compose -f docker-compose.prod.yml down -v
+docker compose down -v
 ```
 
-## Building from Source (without Docker)
+`down -v` is destructive — it removes the named volumes. Take a backup first if the data matters.
 
-If you prefer not to use Docker:
+---
+
+## Building from source without Docker
+
+If you prefer not to use Docker at all:
 
 ### Requirements
 
-- Go 1.22+
+- Go 1.25+
 - Node.js 20+
 - PostgreSQL 17
 - Redis 7
@@ -151,7 +225,7 @@ cd backend && make build
 ```bash
 cd backend
 cp .env.example .env
-# Edit .env with your database credentials
+# fill DATABASE_URL, JWT_SECRET, PUBLIC_URL
 make migrate
 ./bin/senddock
 ```

--- a/docs/self-hosting/updating.md
+++ b/docs/self-hosting/updating.md
@@ -1,6 +1,6 @@
 # Updating
 
-SendDock checks for new releases on its own and tells you when one is available. The dashboard displays the current version next to the logout button. When a newer version is published on Docker Hub / GitHub, the version label turns into a yellow "Update available" badge — click it to see what changed and copy the update command.
+SendDock checks for new releases on its own and tells you when one is available. The dashboard displays the current version next to the logout button. When a newer version is published on GitHub, the version label turns into a yellow "Update available" badge — click it to see what changed and copy the update command.
 
 Behind the scenes the dashboard polls `GET /api/v1/version` once on load. The backend caches the GitHub releases response in Redis for 1 hour, so check traffic stays well inside GitHub's anonymous rate limit even with hundreds of self-hosters.
 
@@ -18,7 +18,7 @@ In every case **your data is preserved**. Postgres lives in a named Docker volum
 
 ## Updating a prebuilt image install
 
-Use this when you installed via the canonical `arkhe-systems/senddock` image (Option 1 in [Installation](./installation)).
+Use this when you installed via the canonical `ghcr.io/arkhe-systems/senddock` image (Option 1 in [Installation](./installation)).
 
 ```bash
 cd senddock
@@ -29,7 +29,7 @@ docker compose logs -f senddock
 
 What happens:
 
-1. `docker compose pull` fetches the latest `arkhe-systems/senddock` image from Docker Hub. Postgres and Redis images update too unless you've pinned them.
+1. `docker compose pull` fetches the latest `ghcr.io/arkhe-systems/senddock` image from GitHub Container Registry. Postgres and Redis images update too unless you've pinned them.
 2. `docker compose up -d` recreates the `senddock` container with the new image. Postgres and Redis containers stay running unless their image changed.
 3. The new container's entrypoint runs `goose -dir /app/migrations postgres "$DATABASE_URL" up`, which applies any new migrations. Existing rows in `goose_db_version` are skipped.
 4. The healthcheck in `docker-compose.yml` flips to "healthy" once `/health` returns 200 — usually within 10 seconds.
@@ -45,7 +45,7 @@ Pin the version in `docker-compose.yml` to control update timing:
 ```yaml
 services:
   senddock:
-    image: arkhe-systems/senddock:0.4.0
+    image: ghcr.io/arkhe-systems/senddock:0.4.0
 ```
 
 When you decide to upgrade, edit the tag, then `docker compose pull && docker compose up -d`.
@@ -94,7 +94,7 @@ If the build fails or the app never becomes healthy, the script exits non-zero a
 For CI/CD pipelines, restricted environments, or step-by-step debugging:
 
 ```bash
-docker pull arkhe-systems/senddock:latest
+docker pull ghcr.io/arkhe-systems/senddock:latest
 docker stop senddock-old
 docker rm senddock-old
 docker run -d \
@@ -102,7 +102,7 @@ docker run -d \
     --env-file /etc/senddock/.env \
     --network senddock-net \
     -p 8080:8080 \
-    arkhe-systems/senddock:latest
+    ghcr.io/arkhe-systems/senddock:latest
 ```
 
 Whatever orchestrator you use (Kubernetes, Nomad, plain systemd-with-podman), the steps boil down to:
@@ -201,4 +201,4 @@ After reset, the next start behaves like a fresh install: setup screen appears, 
 
 ## Checking the current version
 
-The latest release and changelog live on [GitHub releases](https://github.com/arkhe-systems/senddock/releases). The image tag matching that release is published on [Docker Hub](https://hub.docker.com/r/arkhe-systems/senddock/tags) within a few minutes of the GitHub release going live.
+The latest release and changelog live on [GitHub releases](https://github.com/arkhe-systems/senddock/releases). The image tag matching that release is published to [GHCR](https://github.com/Arkhe-Systems/senddock/pkgs/container/senddock) within a few minutes of the GitHub release going live.

--- a/docs/self-hosting/updating.md
+++ b/docs/self-hosting/updating.md
@@ -1,21 +1,72 @@
 # Updating
 
-SendDock checks for new releases on its own and tells you when one is available. The dashboard displays the current version next to the logout button. When a newer version is published on GitHub, the version label turns into a yellow "Update available" badge — click it to see what changed and copy the update command.
+SendDock checks for new releases on its own and tells you when one is available. The dashboard displays the current version next to the logout button. When a newer version is published on Docker Hub / GitHub, the version label turns into a yellow "Update available" badge — click it to see what changed and copy the update command.
 
 Behind the scenes the dashboard polls `GET /api/v1/version` once on load. The backend caches the GitHub releases response in Redis for 1 hour, so check traffic stays well inside GitHub's anonymous rate limit even with hundreds of self-hosters.
 
-Two paths exist depending on what you want to do.
+The update path depends on which install you started from.
 
-| Goal | Command | Loses data? |
-|------|---------|-------------|
-| Pick up a new release, keep all my data | `git pull && ./setup.sh` | No |
-| My install is broken, wipe and start over | `./setup.sh --reset` | **Yes, everything** |
+| Install path | Update command |
+|---|---|
+| Prebuilt image (Option 1) | `docker compose pull && docker compose up -d` |
+| Dokploy (Option 2) | One-click "Redeploy" in the Dokploy UI |
+| Build from source (Option 3) | `git pull && ./setup.sh` |
 
-The `setup.sh` / `setup.ps1` script is the single entry point. It detects what state you're in and acts accordingly — there is no separate `update` command to remember.
+In every case **your data is preserved**. Postgres lives in a named Docker volume that is not touched by image updates. Migrations are run by `goose`, which deduplicates against the `goose_db_version` table and only applies what hasn't been applied before.
 
-## Update without losing data
+---
 
-Use this when a new version is available and you want to keep your subscribers, templates, email history, and configuration.
+## Updating a prebuilt image install
+
+Use this when you installed via the canonical `arkhe-systems/senddock` image (Option 1 in [Installation](./installation)).
+
+```bash
+cd senddock
+docker compose pull
+docker compose up -d
+docker compose logs -f senddock
+```
+
+What happens:
+
+1. `docker compose pull` fetches the latest `arkhe-systems/senddock` image from Docker Hub. Postgres and Redis images update too unless you've pinned them.
+2. `docker compose up -d` recreates the `senddock` container with the new image. Postgres and Redis containers stay running unless their image changed.
+3. The new container's entrypoint runs `goose -dir /app/migrations postgres "$DATABASE_URL" up`, which applies any new migrations. Existing rows in `goose_db_version` are skipped.
+4. The healthcheck in `docker-compose.yml` flips to "healthy" once `/health` returns 200 — usually within 10 seconds.
+
+What is preserved:
+
+- `pgdata` volume (subscribers, templates, projects, logs, campaigns, API keys, audit log)
+- `redisdata` volume (caches; not critical, will rebuild)
+- `.env` (secrets, license key, configuration)
+
+Pin the version in `docker-compose.yml` to control update timing:
+
+```yaml
+services:
+  senddock:
+    image: arkhe-systems/senddock:0.4.0
+```
+
+When you decide to upgrade, edit the tag, then `docker compose pull && docker compose up -d`.
+
+### License key on update
+
+The license validator caches its last-good response for 1 hour. After an update the new container runs through validation again on first startup. If your subscription is active, Pro features unlock immediately. If the license has expired or been revoked, Pro routes start returning `402 Payment Required` on the next validation tick — Core features remain fully available.
+
+---
+
+## Updating a Dokploy install
+
+Open the SendDock app in Dokploy → click "Redeploy". Dokploy runs `docker compose pull && docker compose up -d` against the same volumes.
+
+If you switch to a pinned version, edit the env var in Dokploy and Redeploy. The volume is not touched.
+
+---
+
+## Updating a source build
+
+Use this when you installed via `git clone` + `./setup.sh`.
 
 ```bash
 cd senddock
@@ -24,122 +75,130 @@ git pull origin main
 .\setup.ps1       # Windows
 ```
 
-What is preserved:
-
-- `.env` (secrets, database password, JWT secret, configuration)
-- Postgres volume (subscribers, templates, projects, logs, campaigns, API keys)
-- Redis volume (caches; not critical, will rebuild)
-
-What happens during the update:
+What happens:
 
 1. Detects the existing `.env` and reuses it.
-2. `docker compose build --pull` rebuilds the image with the new code.
+2. `docker compose -f docker-compose.prod.yml build --pull` rebuilds the image with the new code and pulls fresh base images.
 3. `docker compose up -d` restarts the services.
-4. The `entrypoint.sh` runs any new migrations on the existing database.
+4. The container's entrypoint runs any new migrations on the existing database.
 5. A health check polls `GET /health` for up to 60 seconds. The script only reports success once SendDock actually responds.
 
-If the build fails or the app never becomes healthy, the script exits non-zero and points at `docker compose logs app`.
+Same data preservation guarantees as the image flow.
 
-## Clean reinstall (wipe everything)
+If the build fails or the app never becomes healthy, the script exits non-zero and points at `docker compose logs senddock`.
 
-Use this only when:
+---
 
-- Your install is broken in a way that an update can't fix (corrupted volume, password mismatch you can't recover from, etc.).
-- You're testing on a throwaway instance.
-- You took a backup and want a fresh start.
+## Manual update without scripts or Compose
 
-```bash
-./setup.sh --reset        # Linux / macOS
-.\setup.ps1 -Reset        # Windows
-```
-
-What gets deleted:
-
-- Both Docker volumes (Postgres + Redis) — **all your data**.
-- `.env` (regenerated with new secrets).
-- Existing containers (recreated from scratch).
-
-After reset, the script behaves like a fresh install: generates a new `.env`, builds the image, starts services, waits for the health check, and prompts you to create the admin account at `http://localhost:8080`.
-
-## Manual update without the setup script
-
-If you want to control each step yourself (CI/CD pipelines, restricted environments, debugging a release):
+For CI/CD pipelines, restricted environments, or step-by-step debugging:
 
 ```bash
-cd senddock
-git fetch origin
-git status                             # confirm there are no local changes you want to keep
-git reset --hard origin/main           # or origin/v0.x.x for a specific tag
-docker compose -f docker-compose.prod.yml build --pull
-docker compose -f docker-compose.prod.yml up -d
-docker compose -f docker-compose.prod.yml logs -f app
+docker pull arkhe-systems/senddock:latest
+docker stop senddock-old
+docker rm senddock-old
+docker run -d \
+    --name senddock \
+    --env-file /etc/senddock/.env \
+    --network senddock-net \
+    -p 8080:8080 \
+    arkhe-systems/senddock:latest
 ```
 
-Same idea on Windows:
+Whatever orchestrator you use (Kubernetes, Nomad, plain systemd-with-podman), the steps boil down to:
 
-```powershell
-cd senddock
-git fetch origin
-git reset --hard origin/main
-docker compose -f docker-compose.prod.yml build --pull
-docker compose -f docker-compose.prod.yml up -d
-docker compose -f docker-compose.prod.yml logs -f app
-```
+1. Pull the new image.
+2. Stop the old container.
+3. Start a new container against the same `DATABASE_URL` and `JWT_SECRET`.
+4. The entrypoint runs `goose up`. New migrations apply, old ones are skipped.
 
-What each step does:
+---
 
-- `git fetch origin` — downloads remote refs without touching your working tree.
-- `git reset --hard origin/main` — replaces your working tree with the remote contents. **Drops any local edits** to repo files. Your `.env` stays because it is gitignored.
-- `docker compose build --pull` — rebuilds the image with the new code and pulls fresh base images.
-- `docker compose up -d` — restarts the containers; migrations run automatically inside the entrypoint.
-- `docker compose logs -f app` — tail the log so you can see if startup succeeds.
+## Backing up before an update
 
-This is exactly what `setup.sh` does in update mode, just spelled out so you can wedge in extra steps (smoke tests, backups, monitoring) between any two lines.
-
-## Backing up before a reset
-
-Before running `--reset` on a production instance, dump the database:
+While the update path itself is safe, taking a snapshot before any update is good hygiene.
 
 ```bash
-docker compose -f docker-compose.prod.yml exec -T postgres pg_dump -U senddock senddock > senddock-backup-$(date +%Y%m%d).sql
+docker compose exec -T postgres pg_dump -U senddock senddock \
+    > senddock-backup-$(date +%Y%m%d).sql
 ```
 
 To restore later into a fresh install:
 
 ```bash
-cat senddock-backup-YYYYMMDD.sql | docker compose -f docker-compose.prod.yml exec -T postgres psql -U senddock senddock
+cat senddock-backup-YYYYMMDD.sql | \
+    docker compose exec -T postgres psql -U senddock senddock
 ```
 
-## Updating without Docker
+---
 
-If you build SendDock from source instead of using Docker, the update flow is manual:
+## Rolling back
+
+### Image install
+
+Edit `docker-compose.yml` to point at the previous tag, then:
 
 ```bash
-cd senddock
-git pull origin main
-cd frontend && npm ci && npm run build && cd ..
-cd backend
-make migrate
-make build
+docker compose pull
+docker compose up -d
 ```
 
-Restart the `senddock` binary.
+Data is preserved as long as the older version's schema is compatible with what your current database has. Major releases may include irreversible migrations — if rolling back across one, restore from the backup you took before the upgrade.
 
-## Rolling back to a previous version
+### Source build
 
 ```bash
 git checkout v0.x.x
 ./setup.sh
 ```
 
-The script picks up the older code and rebuilds. Data is preserved as long as the older version's schema is compatible with what your current database has — major releases may include irreversible migrations, in which case you need to restore from a backup taken before the upgrade.
+The script picks up the older code and rebuilds.
 
-To roll back a single migration manually (without Docker):
+### Manual migration rollback
+
+If a single migration is the problem:
 
 ```bash
-goose -dir backend/migrations postgres "$DATABASE_URL" down
+docker compose exec senddock goose -dir /app/migrations postgres "$DATABASE_URL" down
 ```
+
+Run it once per migration you want to undo. Verify the application still starts before doing more.
+
+---
+
+## Wiping and reinstalling
+
+Use this only when:
+
+- Your install is broken in a way that an update can't fix (corrupted volume, password mismatch you can't recover from).
+- You're testing on a throwaway instance.
+- You took a backup and want a fresh start.
+
+### Image install
+
+```bash
+docker compose down -v
+docker compose up -d
+```
+
+`down -v` removes the named volumes — **all data is gone**.
+
+### Source build
+
+```bash
+./setup.sh --reset        # Linux / macOS
+.\setup.ps1 -Reset        # Windows
+```
+
+What gets deleted in either flow:
+
+- Both Docker volumes (Postgres + Redis) — all your data.
+- For source builds, `.env` is regenerated with new secrets.
+
+After reset, the next start behaves like a fresh install: setup screen appears, create the admin account again.
+
+---
 
 ## Checking the current version
 
-The latest release and changelog live on [GitHub releases](https://github.com/arkhe-systems/senddock/releases).
+The latest release and changelog live on [GitHub releases](https://github.com/arkhe-systems/senddock/releases). The image tag matching that release is published on [Docker Hub](https://hub.docker.com/r/arkhe-systems/senddock/tags) within a few minutes of the GitHub release going live.


### PR DESCRIPTION
Reorganizes the self-host install flow around the canonical `ghcr.io/arkhe-systems/senddock` Docker image, kept side-by-side with the existing build-from-source path.

## What's new

- `docker-compose.image.yml` at the repo root: pulls `ghcr.io/arkhe-systems/senddock` from GHCR, plus Postgres + Redis with healthchecks, named volumes (`pgdata`, `redisdata`), and required env vars enforced via the `:?` syntax. This is also the basis for the Dokploy template.
- `docs/self-hosting/installation.md` reorganized in three install paths by preference:
  1. Prebuilt image — `curl` the compose file, fill `.env`, `docker compose up`
  2. Dokploy one-click
  3. Build from source — the existing `git clone` + `./setup.sh` flow
- `docs/self-hosting/updating.md` rewritten around the same three paths. Headline guarantee: `docker compose pull && up -d` never rewrites the database (named volume + goose dedup against `goose_db_version`). Manual rollback, backups, and license re-validation on update covered.

## What stays

- Reverse-proxy snippets (Caddy + Nginx)
- First-time setup walkthrough
- Build-from-source flow (`./setup.sh` / `./setup.ps1`)
- No-Docker native build instructions

## Free vs Pro tier

The single canonical image is documented honestly: empty `SENDDOCK_LICENSE_KEY` runs Core, valid key unlocks Pro features (gated routes return 402 otherwise).

## Verified

- `vitepress build` succeeds
- All image references use `ghcr.io/arkhe-systems/senddock`