### PR TITLE
feat: click tracking, Pro Analytics UI, custom date ranges

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/olekukonko/ll v0.0.9 // indirect
 	github.com/olekukonko/tablewriter v1.0.7 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/sqlc-dev/pqtype v0.3.0 // indirect
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	github.com/vanng822/css v1.0.1 // indirect
 	go.uber.org/atomic v1.11.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -47,6 +47,8 @@ github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfS
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/sqlc-dev/pqtype v0.3.0 h1:b09TewZ3cSnO5+M1Kqq05y0+OjqIptxELaSayg7bmqk=
+github.com/sqlc-dev/pqtype v0.3.0/go.mod h1:oyUjp5981ctiL9UYvj1bVvCKi8OXkCa0u645hce7CAs=
 github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf h1:pvbZ0lM0XWPBqUKqFU8cmavspvIl9nulOYwdy6IFRRo=
 github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf/go.mod h1:RJID2RhlZKId02nZ62WenDCkgHFerpIOmW0iT7GKmXM=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/backend/internal/db/email_logs.sql.go
+++ b/backend/internal/db/email_logs.sql.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sqlc-dev/pqtype"
 )
 
 const countEmailLogsByProject = `-- name: CountEmailLogsByProject :one
@@ -67,6 +68,17 @@ func (q *Queries) CountEmailLogsByStatus(ctx context.Context, arg CountEmailLogs
 	return count, err
 }
 
+const countEmailLogsClicked = `-- name: CountEmailLogsClicked :one
+SELECT COUNT(*) FROM email_logs WHERE project_id = $1 AND clicked_at IS NOT NULL
+`
+
+func (q *Queries) CountEmailLogsClicked(ctx context.Context, projectID uuid.UUID) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countEmailLogsClicked, projectID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const countEmailLogsOpened = `-- name: CountEmailLogsOpened :one
 SELECT COUNT(*) FROM email_logs WHERE project_id = $1 AND opened_at IS NOT NULL
 `
@@ -78,10 +90,34 @@ func (q *Queries) CountEmailLogsOpened(ctx context.Context, projectID uuid.UUID)
 	return count, err
 }
 
+const createEmailClick = `-- name: CreateEmailClick :exec
+INSERT INTO email_clicks (log_id, url, url_hash, user_agent, ip_address)
+VALUES ($1, $2, $3, $4, $5)
+`
+
+type CreateEmailClickParams struct {
+	LogID     uuid.UUID
+	Url       string
+	UrlHash   string
+	UserAgent sql.NullString
+	IpAddress pqtype.Inet
+}
+
+func (q *Queries) CreateEmailClick(ctx context.Context, arg CreateEmailClickParams) error {
+	_, err := q.db.ExecContext(ctx, createEmailClick,
+		arg.LogID,
+		arg.Url,
+		arg.UrlHash,
+		arg.UserAgent,
+		arg.IpAddress,
+	)
+	return err
+}
+
 const createEmailLog = `-- name: CreateEmailLog :one
 INSERT INTO email_logs (project_id, subscriber_id, template_id, to_email, subject, status, error)
 VALUES ($1, $2, $3, $4, $5, $6, $7)
-RETURNING id, project_id, subscriber_id, template_id, to_email, subject, status, error, sent_at, opened_at
+RETURNING id, project_id, subscriber_id, template_id, to_email, subject, status, error, sent_at, opened_at, clicked_at
 `
 
 type CreateEmailLogParams struct {
@@ -116,12 +152,24 @@ func (q *Queries) CreateEmailLog(ctx context.Context, arg CreateEmailLogParams) 
 		&i.Error,
 		&i.SentAt,
 		&i.OpenedAt,
+		&i.ClickedAt,
 	)
 	return i, err
 }
 
+const getEmailLogProjectID = `-- name: GetEmailLogProjectID :one
+SELECT project_id FROM email_logs WHERE id = $1
+`
+
+func (q *Queries) GetEmailLogProjectID(ctx context.Context, id uuid.UUID) (uuid.UUID, error) {
+	row := q.db.QueryRowContext(ctx, getEmailLogProjectID, id)
+	var project_id uuid.UUID
+	err := row.Scan(&project_id)
+	return project_id, err
+}
+
 const listEmailLogsByProject = `-- name: ListEmailLogsByProject :many
-SELECT id, project_id, subscriber_id, template_id, to_email, subject, status, error, sent_at, opened_at FROM email_logs
+SELECT id, project_id, subscriber_id, template_id, to_email, subject, status, error, sent_at, opened_at, clicked_at FROM email_logs
 WHERE project_id = $1
 ORDER BY sent_at DESC
 LIMIT $2 OFFSET $3
@@ -153,6 +201,7 @@ func (q *Queries) ListEmailLogsByProject(ctx context.Context, arg ListEmailLogsB
 			&i.Error,
 			&i.SentAt,
 			&i.OpenedAt,
+			&i.ClickedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -168,7 +217,7 @@ func (q *Queries) ListEmailLogsByProject(ctx context.Context, arg ListEmailLogsB
 }
 
 const listEmailLogsByProjectFiltered = `-- name: ListEmailLogsByProjectFiltered :many
-SELECT id, project_id, subscriber_id, template_id, to_email, subject, status, error, sent_at, opened_at FROM email_logs
+SELECT id, project_id, subscriber_id, template_id, to_email, subject, status, error, sent_at, opened_at, clicked_at FROM email_logs
 WHERE project_id = $1
 AND ($4::text = '' OR status = $4::text)
 AND ($5::timestamptz = '0001-01-01'::timestamptz OR sent_at >= $5)
@@ -213,6 +262,7 @@ func (q *Queries) ListEmailLogsByProjectFiltered(ctx context.Context, arg ListEm
 			&i.Error,
 			&i.SentAt,
 			&i.OpenedAt,
+			&i.ClickedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -227,11 +277,35 @@ func (q *Queries) ListEmailLogsByProjectFiltered(ctx context.Context, arg ListEm
 	return items, nil
 }
 
+const markEmailClicked = `-- name: MarkEmailClicked :exec
+UPDATE email_logs SET clicked_at = NOW() WHERE id = $1 AND clicked_at IS NULL
+`
+
+func (q *Queries) MarkEmailClicked(ctx context.Context, id uuid.UUID) error {
+	_, err := q.db.ExecContext(ctx, markEmailClicked, id)
+	return err
+}
+
 const markEmailOpened = `-- name: MarkEmailOpened :exec
 UPDATE email_logs SET opened_at = NOW() WHERE id = $1 AND opened_at IS NULL
 `
 
 func (q *Queries) MarkEmailOpened(ctx context.Context, id uuid.UUID) error {
 	_, err := q.db.ExecContext(ctx, markEmailOpened, id)
+	return err
+}
+
+const updateEmailLogStatus = `-- name: UpdateEmailLogStatus :exec
+UPDATE email_logs SET status = $2, error = $3 WHERE id = $1
+`
+
+type UpdateEmailLogStatusParams struct {
+	ID     uuid.UUID
+	Status string
+	Error  sql.NullString
+}
+
+func (q *Queries) UpdateEmailLogStatus(ctx context.Context, arg UpdateEmailLogStatusParams) error {
+	_, err := q.db.ExecContext(ctx, updateEmailLogStatus, arg.ID, arg.Status, arg.Error)
 	return err
 }

--- a/backend/internal/db/models.go
+++ b/backend/internal/db/models.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sqlc-dev/pqtype"
 )
 
 type ApiKey struct {
@@ -37,6 +38,16 @@ type Campaign struct {
 	Subject     string
 }
 
+type EmailClick struct {
+	ID        uuid.UUID
+	LogID     uuid.UUID
+	Url       string
+	UrlHash   string
+	ClickedAt time.Time
+	UserAgent sql.NullString
+	IpAddress pqtype.Inet
+}
+
 type EmailLog struct {
 	ID           uuid.UUID
 	ProjectID    uuid.UUID
@@ -48,6 +59,7 @@ type EmailLog struct {
 	Error        sql.NullString
 	SentAt       time.Time
 	OpenedAt     sql.NullTime
+	ClickedAt    sql.NullTime
 }
 
 type Project struct {

--- a/backend/internal/handler/tracking.go
+++ b/backend/internal/handler/tracking.go
@@ -1,22 +1,29 @@
 package handler
 
 import (
+	"crypto/sha256"
+	"database/sql"
 	"encoding/base64"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/arkhe-systems/senddock/internal/db"
+	"github.com/arkhe-systems/senddock/internal/service"
 	"github.com/google/uuid"
+	"github.com/sqlc-dev/pqtype"
 )
 
 var transparentPixel, _ = base64.StdEncoding.DecodeString("R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7")
 
 type TrackingHandler struct {
 	queries *db.Queries
+	emails  *service.EmailService
 }
 
-func NewTrackingHandler(queries *db.Queries) *TrackingHandler {
-	return &TrackingHandler{queries: queries}
+func NewTrackingHandler(queries *db.Queries, emails *service.EmailService) *TrackingHandler {
+	return &TrackingHandler{queries: queries, emails: emails}
 }
 
 func (h *TrackingHandler) Open(w http.ResponseWriter, r *http.Request) {
@@ -29,4 +36,82 @@ func (h *TrackingHandler) Open(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "image/gif")
 	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")
 	w.Write(transparentPixel)
+}
+
+func (h *TrackingHandler) Click(w http.ResponseWriter, r *http.Request) {
+	logIDStr := r.PathValue("logId")
+	payload := r.PathValue("payload")
+
+	dot := strings.LastIndex(payload, ".")
+	if dot <= 0 {
+		http.Error(w, "invalid tracking link", http.StatusBadRequest)
+		return
+	}
+	encodedURL := payload[:dot]
+	token := payload[dot+1:]
+
+	rawURL, err := h.emails.DecodeClickURL(encodedURL)
+	if err != nil {
+		http.Error(w, "invalid tracking link", http.StatusBadRequest)
+		return
+	}
+
+	if !h.emails.VerifyClickToken(logIDStr, rawURL, token) {
+		http.Error(w, "invalid tracking link", http.StatusBadRequest)
+		return
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		http.Error(w, "invalid tracking link", http.StatusBadRequest)
+		return
+	}
+
+	if lid, err := uuid.Parse(logIDStr); err == nil {
+		h.queries.MarkEmailClicked(r.Context(), lid)
+		h.queries.CreateEmailClick(r.Context(), db.CreateEmailClickParams{
+			LogID:     lid,
+			Url:       rawURL,
+			UrlHash:   shortHash(rawURL),
+			UserAgent: nullString(r.UserAgent()),
+			IpAddress: parseIP(r),
+		})
+	}
+
+	http.Redirect(w, r, rawURL, http.StatusFound)
+}
+
+func shortHash(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return base64.RawURLEncoding.EncodeToString(h[:])[:16]
+}
+
+func nullString(s string) sql.NullString {
+	if s == "" {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: s, Valid: true}
+}
+
+func parseIP(r *http.Request) pqtype.Inet {
+	host := r.Header.Get("X-Forwarded-For")
+	if comma := strings.Index(host, ","); comma >= 0 {
+		host = host[:comma]
+	}
+	host = strings.TrimSpace(host)
+	if host == "" {
+		host, _, _ = net.SplitHostPort(r.RemoteAddr)
+	}
+	if host == "" {
+		return pqtype.Inet{}
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return pqtype.Inet{}
+	}
+	mask := net.CIDRMask(32, 32)
+	if ip.To4() == nil {
+		mask = net.CIDRMask(128, 128)
+	}
+	return pqtype.Inet{IPNet: net.IPNet{IP: ip, Mask: mask}, Valid: true}
 }

--- a/backend/internal/service/email.go
+++ b/backend/internal/service/email.go
@@ -597,6 +597,23 @@ const (
 	smtpSessionTimeout = 30 * time.Second
 )
 
+func wrapDialError(addr string, err error) error {
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return fmt.Errorf("could not reach SMTP server at %s within %s. The host or port may be wrong, or your network is blocking outbound SMTP (residential ISPs often block ports 25/465/587). Try from a cloud server or use a local SMTP catcher like Mailpit", addr, smtpConnectTimeout)
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		if strings.Contains(err.Error(), "connection refused") {
+			return fmt.Errorf("connection to %s refused. The SMTP server is up but not accepting connections on this port — confirm the port number with your provider", addr)
+		}
+		if strings.Contains(err.Error(), "no such host") {
+			return fmt.Errorf("DNS lookup failed for SMTP host. Confirm the hostname is correct (no typos, no http:// prefix)")
+		}
+	}
+	return fmt.Errorf("smtp connection failed: %w", err)
+}
+
 func deliverSMTP(host, addr, user, pass, from, to string, msg []byte, implicitTLS bool) error {
 	tlsConfig := &tls.Config{ServerName: host, InsecureSkipVerify: true}
 	dialer := &net.Dialer{Timeout: smtpConnectTimeout}
@@ -605,14 +622,11 @@ func deliverSMTP(host, addr, user, pass, from, to string, msg []byte, implicitTL
 	var err error
 	if implicitTLS {
 		conn, err = tls.DialWithDialer(dialer, "tcp", addr, tlsConfig)
-		if err != nil {
-			return fmt.Errorf("smtp tls connection failed: %w", err)
-		}
 	} else {
 		conn, err = dialer.Dial("tcp", addr)
-		if err != nil {
-			return fmt.Errorf("smtp connection failed: %w", err)
-		}
+	}
+	if err != nil {
+		return wrapDialError(addr, err)
 	}
 	defer conn.Close()
 

--- a/backend/internal/service/email.go
+++ b/backend/internal/service/email.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/PuerkitoBio/goquery"
 	"github.com/arkhe-systems/senddock/internal/cache"
 	"github.com/arkhe-systems/senddock/internal/db"
 	"github.com/google/uuid"
@@ -130,12 +131,8 @@ func (s *EmailService) SendToSubscriber(ctx context.Context, projectID, subscrib
 	unsubURL := s.unsubURL(pid.String(), sid.String())
 	body = strings.ReplaceAll(body, "{{unsubscribe_url}}", unsubURL)
 
-	logID := s.logEmail(ctx, pid, uuid.NullUUID{UUID: sid, Valid: true}, uuid.NullUUID{UUID: tid, Valid: true}, sub.Email, subject, nil)
-	body = s.injectTrackingPixel(body, logID)
-
-	sendErr := s.sendSMTP(project, sub.Email, subject, body, unsubURL)
+	sendErr := s.trackAndSend(ctx, project, pid, uuid.NullUUID{UUID: sid, Valid: true}, uuid.NullUUID{UUID: tid, Valid: true}, sub.Email, subject, body, unsubURL)
 	if sendErr != nil {
-		s.logEmail(ctx, pid, uuid.NullUUID{UUID: sid, Valid: true}, uuid.NullUUID{UUID: tid, Valid: true}, sub.Email, subject, sendErr)
 		return SendResult{Failed: 1}, sendErr
 	}
 	return SendResult{Sent: 1}, nil
@@ -209,8 +206,7 @@ func (s *EmailService) Broadcast(ctx context.Context, projectID, templateID, sub
 			unsubURL := s.unsubURL(pid.String(), sub.ID.String())
 			body = strings.ReplaceAll(body, "{{unsubscribe_url}}", unsubURL)
 
-			sendErr := s.sendSMTP(project, sub.Email, subject, body, unsubURL)
-			s.logEmail(bgCtx, pid, uuid.NullUUID{UUID: sub.ID, Valid: true}, uuid.NullUUID{UUID: tid, Valid: true}, sub.Email, subject, sendErr)
+			s.trackAndSend(bgCtx, project, pid, uuid.NullUUID{UUID: sub.ID, Valid: true}, uuid.NullUUID{UUID: tid, Valid: true}, sub.Email, subject, body, unsubURL)
 		}
 		log.Printf("Broadcast to %d subscribers completed for project %s", total, pid.String())
 	}()
@@ -233,11 +229,7 @@ func (s *EmailService) SendDirect(ctx context.Context, projectID, to, subject, h
 		return errors.New("smtp not configured")
 	}
 
-	sendErr := s.sendSMTP(project, to, subject, htmlBody, "")
-
-	s.logEmail(ctx, pid, uuid.NullUUID{}, uuid.NullUUID{}, to, subject, sendErr)
-
-	return sendErr
+	return s.trackAndSend(ctx, project, pid, uuid.NullUUID{}, uuid.NullUUID{}, to, subject, htmlBody, "")
 }
 
 func (s *EmailService) SendWithTemplate(ctx context.Context, projectID, templateID, to, subjectOverride string, variables map[string]string) error {
@@ -287,11 +279,7 @@ func (s *EmailService) SendWithTemplate(ctx context.Context, projectID, template
 		body = strings.ReplaceAll(body, "{{unsubscribe_url}}", unsubscribeURL)
 	}
 
-	sendErr := s.sendSMTP(project, to, subject, body, unsubscribeURL)
-
-	s.logEmail(ctx, pid, uuid.NullUUID{}, uuid.NullUUID{UUID: tid, Valid: true}, to, subject, sendErr)
-
-	return sendErr
+	return s.trackAndSend(ctx, project, pid, uuid.NullUUID{}, uuid.NullUUID{UUID: tid, Valid: true}, to, subject, body, unsubscribeURL)
 }
 
 func (s *EmailService) GetLogs(ctx context.Context, projectID string, limit, offset int32, status, from, to string) ([]db.EmailLog, int64, error) {
@@ -376,26 +364,38 @@ func (s *EmailService) GetStats(ctx context.Context, projectID string) (map[stri
 	return stats, nil
 }
 
-func (s *EmailService) logEmail(ctx context.Context, projectID uuid.UUID, subscriberID, templateID uuid.NullUUID, toEmail, subject string, sendErr error) uuid.UUID {
-	status := "sent"
-	var errMsg sql.NullString
-	if sendErr != nil {
-		status = "failed"
-		errMsg = sql.NullString{String: sendErr.Error(), Valid: true}
-	}
-
+func (s *EmailService) logPending(ctx context.Context, projectID uuid.UUID, subscriberID, templateID uuid.NullUUID, toEmail, subject string) uuid.UUID {
 	logEntry, _ := s.queries.CreateEmailLog(ctx, db.CreateEmailLogParams{
 		ProjectID:    projectID,
 		SubscriberID: subscriberID,
 		TemplateID:   templateID,
 		ToEmail:      toEmail,
 		Subject:      subject,
-		Status:       status,
-		Error:        errMsg,
+		Status:       "sent",
 	})
-
 	s.cache.Delete(ctx, "stats:"+projectID.String())
 	return logEntry.ID
+}
+
+func (s *EmailService) markLogFailed(ctx context.Context, projectID, logID uuid.UUID, sendErr error) {
+	if sendErr == nil || logID == uuid.Nil {
+		return
+	}
+	s.queries.UpdateEmailLogStatus(ctx, db.UpdateEmailLogStatusParams{
+		ID:     logID,
+		Status: "failed",
+		Error:  sql.NullString{String: sendErr.Error(), Valid: true},
+	})
+	s.cache.Delete(ctx, "stats:"+projectID.String())
+}
+
+func (s *EmailService) trackAndSend(ctx context.Context, project db.Project, projectID uuid.UUID, subscriberID, templateID uuid.NullUUID, to, subject, body, unsubscribeURL string) error {
+	logID := s.logPending(ctx, projectID, subscriberID, templateID, to, subject)
+	body = s.injectTrackingPixel(body, logID)
+	body = s.rewriteLinksForTracking(body, logID)
+	sendErr := s.sendSMTP(project, to, subject, body, unsubscribeURL)
+	s.markLogFailed(ctx, projectID, logID, sendErr)
+	return sendErr
 }
 
 func (s *EmailService) injectTrackingPixel(body string, logID uuid.UUID) string {
@@ -404,6 +404,77 @@ func (s *EmailService) injectTrackingPixel(body string, logID uuid.UUID) string 
 		return strings.Replace(body, "</body>", pixel+"</body>", 1)
 	}
 	return body + pixel
+}
+
+func (s *EmailService) signClickToken(logID, rawURL string) string {
+	mac := hmac.New(sha256.New, []byte(s.encSecret))
+	mac.Write([]byte(logID + ":" + rawURL))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))[:22]
+}
+
+func (s *EmailService) verifyClickToken(logID, rawURL, token string) bool {
+	expected := s.signClickToken(logID, rawURL)
+	return hmac.Equal([]byte(expected), []byte(token))
+}
+
+func (s *EmailService) clickURL(logID uuid.UUID, rawURL string) string {
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(rawURL))
+	sig := s.signClickToken(logID.String(), rawURL)
+	return fmt.Sprintf("%s/c/%s/%s.%s", s.publicURL, logID.String(), encoded, sig)
+}
+
+func shortURLHash(rawURL string) string {
+	h := sha256.Sum256([]byte(rawURL))
+	return base64.RawURLEncoding.EncodeToString(h[:])[:16]
+}
+
+func (s *EmailService) ClickURLHash(rawURL string) string {
+	return shortURLHash(rawURL)
+}
+
+func (s *EmailService) DecodeClickURL(encoded string) (string, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+func (s *EmailService) VerifyClickToken(logID, rawURL, token string) bool {
+	return s.verifyClickToken(logID, rawURL, token)
+}
+
+func (s *EmailService) rewriteLinksForTracking(body string, logID uuid.UUID) string {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(body))
+	if err != nil {
+		return body
+	}
+	doc.Find("a").Each(func(_ int, sel *goquery.Selection) {
+		href, ok := sel.Attr("href")
+		if !ok {
+			return
+		}
+		trimmed := strings.TrimSpace(href)
+		if trimmed == "" {
+			return
+		}
+		lower := strings.ToLower(trimmed)
+		if strings.HasPrefix(lower, "#") || strings.HasPrefix(lower, "mailto:") || strings.HasPrefix(lower, "tel:") {
+			return
+		}
+		if !strings.HasPrefix(lower, "http://") && !strings.HasPrefix(lower, "https://") {
+			return
+		}
+		if strings.HasPrefix(trimmed, s.publicURL+"/unsubscribe/") || strings.HasPrefix(trimmed, s.publicURL+"/c/") || strings.HasPrefix(trimmed, s.publicURL+"/t/") {
+			return
+		}
+		sel.SetAttr("href", s.clickURL(logID, trimmed))
+	})
+	out, err := doc.Html()
+	if err != nil {
+		return body
+	}
+	return out
 }
 
 type UnsubscribeContext struct {

--- a/backend/internal/service/email.go
+++ b/backend/internal/service/email.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"html"
 	"log"
+	"net"
 	"net/smtp"
 	"net/url"
 	"strings"
@@ -588,28 +589,50 @@ func (s *EmailService) sendSMTP(project db.Project, to, subject, htmlBody, unsub
 
 	addr := fmt.Sprintf("%s:%d", host, port)
 
-	if port == 465 {
-		return sendSMTPImplicitTLS(host, addr, user, pass, fromEmail, to, []byte(msg))
-	}
-
-	auth := smtp.PlainAuth("", user, pass, host)
-	return smtp.SendMail(addr, auth, fromEmail, []string{to}, []byte(msg))
+	return deliverSMTP(host, addr, user, pass, fromEmail, to, []byte(msg), port == 465)
 }
 
-func sendSMTPImplicitTLS(host, addr, user, pass, from, to string, msg []byte) error {
-	tlsConfig := &tls.Config{ServerName: host, InsecureSkipVerify: true}
+const (
+	smtpConnectTimeout = 10 * time.Second
+	smtpSessionTimeout = 30 * time.Second
+)
 
-	conn, err := tls.Dial("tcp", addr, tlsConfig)
-	if err != nil {
-		return fmt.Errorf("tls connection failed: %w", err)
+func deliverSMTP(host, addr, user, pass, from, to string, msg []byte, implicitTLS bool) error {
+	tlsConfig := &tls.Config{ServerName: host, InsecureSkipVerify: true}
+	dialer := &net.Dialer{Timeout: smtpConnectTimeout}
+
+	var conn net.Conn
+	var err error
+	if implicitTLS {
+		conn, err = tls.DialWithDialer(dialer, "tcp", addr, tlsConfig)
+		if err != nil {
+			return fmt.Errorf("smtp tls connection failed: %w", err)
+		}
+	} else {
+		conn, err = dialer.Dial("tcp", addr)
+		if err != nil {
+			return fmt.Errorf("smtp connection failed: %w", err)
+		}
 	}
 	defer conn.Close()
+
+	if err := conn.SetDeadline(time.Now().Add(smtpSessionTimeout)); err != nil {
+		return fmt.Errorf("smtp set deadline failed: %w", err)
+	}
 
 	client, err := smtp.NewClient(conn, host)
 	if err != nil {
 		return fmt.Errorf("smtp client failed: %w", err)
 	}
 	defer client.Close()
+
+	if !implicitTLS {
+		if ok, _ := client.Extension("STARTTLS"); ok {
+			if err = client.StartTLS(tlsConfig); err != nil {
+				return fmt.Errorf("smtp starttls failed: %w", err)
+			}
+		}
+	}
 
 	auth := smtp.PlainAuth("", user, pass, host)
 	if err = client.Auth(auth); err != nil {
@@ -628,14 +651,10 @@ func sendSMTPImplicitTLS(host, addr, user, pass, from, to string, msg []byte) er
 	if err != nil {
 		return fmt.Errorf("smtp data failed: %w", err)
 	}
-
-	_, err = w.Write(msg)
-	if err != nil {
+	if _, err = w.Write(msg); err != nil {
 		return fmt.Errorf("smtp write failed: %w", err)
 	}
-
-	err = w.Close()
-	if err != nil {
+	if err = w.Close(); err != nil {
 		return fmt.Errorf("smtp close failed: %w", err)
 	}
 

--- a/backend/migrations/20260428003858_add_click_tracking.sql
+++ b/backend/migrations/20260428003858_add_click_tracking.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+ALTER TABLE email_logs ADD COLUMN clicked_at TIMESTAMPTZ;
+
+CREATE TABLE email_clicks (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    log_id UUID NOT NULL REFERENCES email_logs(id) ON DELETE CASCADE,
+    url TEXT NOT NULL,
+    url_hash VARCHAR(16) NOT NULL,
+    clicked_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    user_agent TEXT,
+    ip_address INET
+);
+
+CREATE INDEX idx_email_clicks_log_id ON email_clicks(log_id);
+CREATE INDEX idx_email_clicks_url_hash ON email_clicks(url_hash);
+CREATE INDEX idx_email_clicks_clicked_at ON email_clicks(clicked_at DESC);
+
+-- +goose Down
+DROP TABLE email_clicks;
+ALTER TABLE email_logs DROP COLUMN clicked_at;

--- a/backend/pkg/app/app.go
+++ b/backend/pkg/app/app.go
@@ -173,7 +173,7 @@ func (a *App) registerCoreRoutes(emailService *service.EmailService) {
 	campaignService := service.NewCampaignService(queries)
 	campaignHandler := handler.NewCampaignHandler(campaignService, projectService, cfg.PublicURL)
 
-	trackingHandler := handler.NewTrackingHandler(queries)
+	trackingHandler := handler.NewTrackingHandler(queries, emailService)
 
 	releaseService := service.NewReleaseService(a.cache)
 	releaseHandler := handler.NewReleaseHandler(releaseService)
@@ -248,6 +248,7 @@ func (a *App) registerCoreRoutes(emailService *service.EmailService) {
 	mux.HandleFunc("POST /unsubscribe/{id}/{subscriberId}", emailHandler.Unsubscribe)
 
 	mux.HandleFunc("GET /t/{logId}", trackingHandler.Open)
+	mux.HandleFunc("GET /c/{logId}/{payload}", trackingHandler.Click)
 	mux.HandleFunc("POST /api/v1/projects/{id}/waitlist", waitlistHandler.Join)
 	mux.HandleFunc("OPTIONS /api/v1/projects/{id}/waitlist", waitlistHandler.Join)
 
@@ -272,7 +273,7 @@ func (a *App) serveFrontend() {
 	fileServer := http.FileServerFS(frontendFS)
 
 	a.mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/api/") || strings.HasPrefix(r.URL.Path, "/unsubscribe/") || strings.HasPrefix(r.URL.Path, "/t/") || r.URL.Path == "/health" {
+		if strings.HasPrefix(r.URL.Path, "/api/") || strings.HasPrefix(r.URL.Path, "/unsubscribe/") || strings.HasPrefix(r.URL.Path, "/t/") || strings.HasPrefix(r.URL.Path, "/c/") || r.URL.Path == "/health" {
 			http.NotFound(w, r)
 			return
 		}

--- a/backend/sqlc/queries/email_logs.sql
+++ b/backend/sqlc/queries/email_logs.sql
@@ -36,3 +36,19 @@ UPDATE email_logs SET opened_at = NOW() WHERE id = $1 AND opened_at IS NULL;
 
 -- name: CountEmailLogsOpened :one
 SELECT COUNT(*) FROM email_logs WHERE project_id = $1 AND opened_at IS NOT NULL;
+
+-- name: MarkEmailClicked :exec
+UPDATE email_logs SET clicked_at = NOW() WHERE id = $1 AND clicked_at IS NULL;
+
+-- name: CountEmailLogsClicked :one
+SELECT COUNT(*) FROM email_logs WHERE project_id = $1 AND clicked_at IS NOT NULL;
+
+-- name: CreateEmailClick :exec
+INSERT INTO email_clicks (log_id, url, url_hash, user_agent, ip_address)
+VALUES ($1, $2, $3, $4, $5);
+
+-- name: GetEmailLogProjectID :one
+SELECT project_id FROM email_logs WHERE id = $1;
+
+-- name: UpdateEmailLogStatus :exec
+UPDATE email_logs SET status = $2, error = $3 WHERE id = $1;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,16 @@ services:
     ports:
       - "6380:6379"
 
+  mailpit:
+    image: axllent/mailpit:latest
+    profiles: ["mail"]
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+    environment:
+      MP_SMTP_AUTH_ACCEPT_ANY: "true"
+      MP_SMTP_AUTH_ALLOW_INSECURE: "true"
+    restart: unless-stopped
+
 volumes:
   pgdata:
-  

--- a/docs/guide/smtp.md
+++ b/docs/guide/smtp.md
@@ -19,6 +19,16 @@ Go to **SMTP Settings** in the project sidebar and fill in:
 
 After saving, click **Test Connection**. SendDock will send a test email to the configured from address (or SMTP username) to verify the connection works.
 
+::: warning Why your local install times out
+Most residential ISPs (Comcast, Claro, Movistar, BT, and many more) block outbound TCP ports 25, 465 and 587 at the network edge to prevent spam botnets. This means a SendDock instance running on your laptop or home server **cannot reach external SMTP providers** at all — it has nothing to do with SendDock or your credentials. You will see a 10-second timeout error.
+
+There are three ways around it:
+
+1. **Run SendDock on a public domain / cloud server.** Cloud providers (DigitalOcean, Hetzner, AWS, etc.) do not apply the residential SMTP block. This is the supported production setup. See [Installation](/self-hosting/installation).
+2. **Use port 2525 if your provider supports it.** SendGrid, Mailgun, Postmark, Resend and Brevo all listen on `2525` specifically as an escape hatch for ISP-blocked users. Self-hosted Mailcow / Postfix / Stalwart instances can be configured the same way.
+3. **For local development**, use a fake SMTP catcher like [Mailpit](https://mailpit.axllent.org/) — it accepts any auth on `localhost:1025` and shows captured emails in a web UI. SendDock ships a `mail` profile in its dev `docker-compose.yml` for exactly this case.
+:::
+
 ## Common SMTP Providers
 
 ### Gmail

--- a/docs/self-hosting/installation.md
+++ b/docs/self-hosting/installation.md
@@ -6,8 +6,16 @@ SendDock ships as a single Docker image: `ghcr.io/arkhe-systems/senddock`. Three
 
 - A Linux server (Ubuntu, Debian, etc.)
 - Docker and Docker Compose
+- A **publicly reachable domain** pointed at the server (required for unsubscribe links, broadcasts, and SMTP)
+- The server's network must allow **outbound TCP** on the SMTP port your provider uses (usually 465 or 587)
 
 That's it. Everything else is handled by Docker.
+
+::: warning Don't expect to send real emails from a laptop
+Most residential ISPs block outbound SMTP ports (25, 465, 587) at the network edge to prevent spam botnets. A SendDock instance on your home network cannot deliver mail through any external SMTP provider — including Gmail, SES, Mailgun, or your own Mailcow if it lives elsewhere. **SendDock in production must run on a cloud server (DigitalOcean, Hetzner, AWS, etc.) where outbound SMTP is unblocked.**
+
+For local development and evaluation, ship `make mail` (or any other [Mailpit](https://mailpit.axllent.org/)-like catcher) and configure SendDock to talk to it on `localhost:1025`. See the [SMTP guide](/guide/smtp) for the workaround details.
+:::
 
 ---
 

--- a/docs/self-hosting/troubleshooting.md
+++ b/docs/self-hosting/troubleshooting.md
@@ -4,6 +4,21 @@ Common problems you might run into when self-hosting SendDock, and how to fix th
 
 ## Outgoing emails
 
+### Test Connection times out / "could not reach SMTP server within 10s"
+
+**Symptom:** SMTP Settings → Test Connection sits for 10 seconds, then errors with a message about ISPs blocking outbound SMTP. The same SMTP credentials work fine from another machine (cloud, office, phone tether).
+
+**Cause:** Your network — almost certainly a residential ISP (Comcast, Claro, Movistar, BT, and most others worldwide) — blocks outbound TCP on ports 25, 465 and 587 to stop spam botnets. The block is at the ISP's edge router, so the TCP packet never leaves your house. Every email tool hits the same wall — it is not specific to SendDock.
+
+**Fix (in order of preference):**
+
+1. **Run SendDock on a public cloud server** (DigitalOcean, Hetzner, AWS, etc.). Cloud providers don't apply the residential SMTP block. This is the supported production deployment.
+2. **Ask your SMTP provider for port `2525`.** SendGrid, Mailgun, Postmark, Resend and Brevo all listen on `2525` specifically as an escape hatch. If your provider does, change Port to `2525` and Test Connection again.
+3. **Use a VPN** that doesn't apply ISP filters. Paid VPNs (NordVPN, Mullvad, ProtonVPN) work; free ones often also block SMTP.
+4. **For local dev**, use [Mailpit](https://mailpit.axllent.org/) on `localhost:1025` — see the [SMTP guide](/guide/smtp#testing) for the workflow. Mailpit captures sends without ever leaving the host.
+
+In other words: SendDock cannot deliver mail from a network that blocks outbound mail ports. There is no software workaround for ISP egress filtering.
+
 ### 429 "rate limit exceeded for this project on this endpoint"
 
 **Cause:** You hit the per-project rate limit on a sending endpoint. The limits are intentional spam protection. See [Rate limits](/guide/sending#rate-limits-and-abuse-prevention) for the full table.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -6,6 +6,12 @@ interface ApiOptions {
     _retry?: boolean
 }
 
+let onSessionExpired: (() => void) | null = null
+
+export function setSessionExpiredHandler(fn: () => void) {
+    onSessionExpired = fn
+}
+
 export async function api<T>(endpoint: string, options: ApiOptions = {}): Promise<T> {
     const { method = 'GET', body, _retry = false } = options
 
@@ -30,6 +36,7 @@ export async function api<T>(endpoint: string, options: ApiOptions = {}): Promis
             return api<T>(endpoint, { ...options, _retry: true })
         }
 
+        if (onSessionExpired) onSessionExpired()
         throw new Error('session_expired')
     }
 

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1,1 +1,20 @@
 @import "tailwindcss";
+
+input[type="date"]::-webkit-calendar-picker-indicator,
+input[type="datetime-local"]::-webkit-calendar-picker-indicator,
+input[type="time"]::-webkit-calendar-picker-indicator,
+input[type="month"]::-webkit-calendar-picker-indicator,
+input[type="week"]::-webkit-calendar-picker-indicator {
+    filter: invert(1);
+    opacity: 0.5;
+    cursor: pointer;
+    transition: opacity 0.15s ease;
+}
+
+input[type="date"]::-webkit-calendar-picker-indicator:hover,
+input[type="datetime-local"]::-webkit-calendar-picker-indicator:hover,
+input[type="time"]::-webkit-calendar-picker-indicator:hover,
+input[type="month"]::-webkit-calendar-picker-indicator:hover,
+input[type="week"]::-webkit-calendar-picker-indicator:hover {
+    opacity: 1;
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3,6 +3,9 @@ import { createPinia } from 'pinia'
 
 import App from './App.vue'
 import router from './router'
+import { setSessionExpiredHandler } from './api/client'
+import { useAuthStore } from './stores/auth'
+import { useToastStore } from './stores/toast'
 
 import './assets/main.css'
 
@@ -10,5 +13,16 @@ const app = createApp(App)
 
 app.use(createPinia())
 app.use(router)
+
+setSessionExpiredHandler(() => {
+    const auth = useAuthStore()
+    auth.isAuthenticated = false
+    auth.sessionExpired = true
+    const toast = useToastStore()
+    toast.error('Your session has expired. Please sign in again.')
+    if (router.currentRoute.value.name !== 'login') {
+        router.push({ name: 'login', query: { reason: 'session_expired' } })
+    }
+})
 
 app.mount('#app')

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -16,6 +16,7 @@ app.use(router)
 
 setSessionExpiredHandler(() => {
     const auth = useAuthStore()
+    if (auth.sessionExpired) return
     auth.isAuthenticated = false
     auth.sessionExpired = true
     const toast = useToastStore()

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -70,6 +70,11 @@ const router = createRouter({
           component: () => import('@/views/project/CampaignsSection.vue'),
         },
         {
+          path: 'analytics',
+          name: 'project-analytics',
+          component: () => import('@/views/project/AnalyticsSection.vue'),
+        },
+        {
           path: 'settings',
           name: 'project-settings',
           component: () => import('@/views/project/SettingsSection.vue'),

--- a/frontend/src/views/project/AnalyticsSection.vue
+++ b/frontend/src/views/project/AnalyticsSection.vue
@@ -1,0 +1,500 @@
+<script setup lang="ts">
+import { ref, onMounted, computed } from 'vue'
+import { api } from '@/api/client'
+import type { Project } from '@/stores/projects'
+
+interface OpenBucket { day: string; opens: number }
+interface TemplateStat { template_id: string; name: string; sends: number }
+interface StatusBucket { status: string; count: number }
+interface PeriodMetrics {
+    total_sent: number
+    total_failed: number
+    total_opened: number
+    deliverability_pct: number
+    open_rate_pct: number
+}
+interface Overview {
+    range_days: number
+    total_sent: number
+    total_failed: number
+    total_opened: number
+    deliverability_pct: number
+    open_rate_pct: number
+    opens_by_day: OpenBucket[] | null
+    top_templates: TemplateStat[] | null
+    active_subscribers: number
+    sends_by_status: StatusBucket[] | null
+    previous: PeriodMetrics
+}
+
+const props = defineProps<{ project: Project }>()
+
+const overview = ref<Overview | null>(null)
+const loading = ref(true)
+const errorState = ref<'none' | 'paywall' | 'generic'>('none')
+const range = ref(30)
+
+const opensByDay = computed(() => overview.value?.opens_by_day ?? [])
+const topTemplates = computed(() => overview.value?.top_templates ?? [])
+
+const totalSendsCurrent = computed(() => {
+    const o = overview.value
+    if (!o) return 0
+    return o.total_sent + o.total_failed
+})
+
+const maxTopSends = computed(() => topTemplates.value.reduce((m, t) => Math.max(m, t.sends), 0) || 1)
+
+interface ChartGeometry {
+    width: number
+    height: number
+    points: { x: number; y: number; day: string; opens: number }[]
+    linePath: string
+    areaPath: string
+}
+
+const chart = computed<ChartGeometry>(() => {
+    const data = opensByDay.value
+    const w = 600
+    const h = 180
+    if (data.length === 0) return { width: w, height: h, points: [], linePath: '', areaPath: '' }
+
+    const max = Math.max(...data.map(d => d.opens), 1)
+    const xStep = data.length === 1 ? 0 : w / (data.length - 1)
+    const points = data.map((d, i) => ({
+        x: data.length === 1 ? w / 2 : i * xStep,
+        y: h - (d.opens / max) * (h - 24) - 12,
+        day: d.day,
+        opens: d.opens,
+    }))
+
+    let line = `M ${points[0].x} ${points[0].y}`
+    for (let i = 1; i < points.length; i++) {
+        const p0 = points[i - 2] ?? points[i - 1]
+        const p1 = points[i - 1]
+        const p2 = points[i]
+        const p3 = points[i + 1] ?? p2
+        const cp1x = p1.x + (p2.x - p0.x) / 6
+        const cp1y = p1.y + (p2.y - p0.y) / 6
+        const cp2x = p2.x - (p3.x - p1.x) / 6
+        const cp2y = p2.y - (p3.y - p1.y) / 6
+        line += ` C ${cp1x} ${cp1y}, ${cp2x} ${cp2y}, ${p2.x} ${p2.y}`
+    }
+    const area = `${line} L ${points[points.length - 1].x} ${h} L ${points[0].x} ${h} Z`
+
+    return { width: w, height: h, points, linePath: line, areaPath: area }
+})
+
+const statusDonut = computed(() => {
+    const o = overview.value
+    if (!o) return { sent: 0, failed: 0, total: 0, sentPct: 0 }
+    const total = o.total_sent + o.total_failed
+    return {
+        sent: o.total_sent,
+        failed: o.total_failed,
+        total,
+        sentPct: total === 0 ? 0 : (o.total_sent / total) * 100,
+    }
+})
+
+interface Trend {
+    direction: 'up' | 'down' | 'flat'
+    pct: number
+    label: string
+}
+
+function trend(current: number, previous: number, invertGood = false): Trend {
+    if (current === 0 && previous === 0) {
+        return { direction: 'flat', pct: 0, label: 'no change' }
+    }
+    if (previous === 0) {
+        return { direction: 'up', pct: 100, label: 'new' }
+    }
+    const delta = ((current - previous) / previous) * 100
+    if (Math.abs(delta) < 0.5) {
+        return { direction: 'flat', pct: 0, label: 'flat' }
+    }
+    const dir = delta > 0 ? 'up' : 'down'
+    return {
+        direction: dir,
+        pct: Math.abs(delta),
+        label: invertGood
+            ? (dir === 'up' ? 'worse' : 'better')
+            : (dir === 'up' ? 'better' : 'worse'),
+    }
+}
+
+const sentTrend = computed(() => overview.value ? trend(overview.value.total_sent, overview.value.previous.total_sent) : null)
+const failedTrend = computed(() => overview.value ? trend(overview.value.total_failed, overview.value.previous.total_failed, true) : null)
+const openedTrend = computed(() => overview.value ? trend(overview.value.total_opened, overview.value.previous.total_opened) : null)
+const openRateTrend = computed(() => overview.value ? trend(overview.value.open_rate_pct, overview.value.previous.open_rate_pct) : null)
+
+const insights = computed(() => {
+    const o = overview.value
+    if (!o) return []
+    const items: { tone: 'good' | 'warn' | 'info'; text: string }[] = []
+
+    if (opensByDay.value.length > 0) {
+        const top = [...opensByDay.value].sort((a, b) => b.opens - a.opens)[0]
+        if (top && top.opens > 0) {
+            const date = new Date(top.day + 'T00:00:00')
+            const weekday = date.toLocaleDateString('en-US', { weekday: 'long' })
+            items.push({
+                tone: 'info',
+                text: `Best day this period: ${weekday} ${top.day.slice(5)} with ${top.opens} open${top.opens === 1 ? '' : 's'}.`,
+            })
+        }
+    }
+
+    if (o.open_rate_pct > 0) {
+        const benchmark = 21
+        if (o.open_rate_pct >= benchmark) {
+            items.push({
+                tone: 'good',
+                text: `Open rate of ${o.open_rate_pct.toFixed(1)}% is above the industry average (~21%). Keep it up.`,
+            })
+        } else {
+            items.push({
+                tone: 'warn',
+                text: `Open rate of ${o.open_rate_pct.toFixed(1)}% is below the industry average (~21%). Try shorter subjects or A/B test send times.`,
+            })
+        }
+    }
+
+    if (o.total_failed > 0 && totalSendsCurrent.value > 0) {
+        const failRate = (o.total_failed / totalSendsCurrent.value) * 100
+        if (failRate >= 5) {
+            items.push({
+                tone: 'warn',
+                text: `Failure rate of ${failRate.toFixed(1)}% is high — check SMTP credentials and recipient list quality.`,
+            })
+        }
+    }
+
+    if (topTemplates.value.length > 0) {
+        const top = topTemplates.value[0]
+        items.push({
+            tone: 'info',
+            text: `Most-used template: ${top.name} with ${top.sends} send${top.sends === 1 ? '' : 's'}.`,
+        })
+    }
+
+    if (totalSendsCurrent.value === 0) {
+        items.push({
+            tone: 'info',
+            text: 'No sends recorded yet in this range. Send a broadcast or transactional email to populate this view.',
+        })
+    }
+
+    return items.slice(0, 4)
+})
+
+async function load() {
+    loading.value = true
+    errorState.value = 'none'
+    try {
+        const url = `/projects/${props.project.id}/analytics/overview?range_days=${range.value}`
+        overview.value = await api<Overview>(url)
+    } catch (e) {
+        const msg = e instanceof Error ? e.message : ''
+        if (msg.includes('license required')) errorState.value = 'paywall'
+        else errorState.value = 'generic'
+    } finally {
+        loading.value = false
+    }
+}
+
+function setRange(days: number) {
+    range.value = days
+    load()
+}
+
+function fmtPct(n: number | undefined) {
+    if (n === undefined || Number.isNaN(n)) return '0.0%'
+    return `${n.toFixed(1)}%`
+}
+
+function fmtDay(iso: string) {
+    const [, m, d] = iso.split('-')
+    return `${d}/${m}`
+}
+
+function rangeLabel(days: number) {
+    return `vs previous ${days}d`
+}
+
+onMounted(load)
+</script>
+
+<template>
+    <div>
+        <div class="flex flex-wrap items-center justify-between gap-3 mb-6">
+            <div>
+                <div class="flex items-center gap-2">
+                    <h1 class="text-2xl font-bold text-white">Analytics</h1>
+                    <span class="text-[10px] font-semibold tracking-wider uppercase px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400 border border-amber-500/30">Pro</span>
+                </div>
+                <p class="text-sm text-zinc-500 mt-1">Send performance and engagement trends</p>
+            </div>
+            <div class="flex gap-1 bg-zinc-900 border border-zinc-800 rounded-lg p-1">
+                <button v-for="r in [7, 30, 90]" :key="r" @click="setRange(r)" :class="[
+                    'px-3 py-1 text-sm rounded-md transition cursor-pointer',
+                    range === r ? 'bg-zinc-800 text-white' : 'text-zinc-400 hover:text-white'
+                ]">{{ r }}d</button>
+            </div>
+        </div>
+
+        <div v-if="loading" class="text-zinc-500 py-8 text-center">Loading...</div>
+
+        <div v-else-if="errorState === 'paywall'"
+            class="bg-zinc-900 border border-zinc-800 rounded-lg p-8 text-center">
+            <h2 class="text-lg font-semibold text-white mb-2">Analytics is a Pro feature</h2>
+            <p class="text-sm text-zinc-400 mb-6 max-w-md mx-auto">
+                Detailed deliverability metrics, open tracking trends and top-template insights
+                require a SendDock Pro license. Activate one to unlock this section.
+            </p>
+            <a href="https://senddock.com/pricing" target="_blank" rel="noopener"
+                class="inline-block px-4 py-2 text-sm font-medium bg-white text-zinc-950 rounded-lg hover:bg-zinc-200 transition">
+                See Pro plans
+            </a>
+        </div>
+
+        <div v-else-if="errorState === 'generic'"
+            class="bg-zinc-900 border border-zinc-800 rounded-lg p-6 text-center">
+            <p class="text-zinc-400 text-sm">Couldn't load analytics. Try again later.</p>
+            <button @click="load" class="mt-3 px-3 py-1 text-sm text-white border border-zinc-700 rounded-md hover:bg-zinc-800 cursor-pointer">Retry</button>
+        </div>
+
+        <div v-else-if="overview">
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+                <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
+                    <p class="text-xs text-zinc-500 uppercase tracking-wide">Sent</p>
+                    <p class="text-3xl font-bold text-white mt-2 tabular-nums">{{ overview.total_sent }}</p>
+                    <div v-if="sentTrend" class="mt-3 flex items-center gap-1.5">
+                        <span :class="[
+                            'inline-flex items-center gap-0.5 text-xs font-medium px-1.5 py-0.5 rounded',
+                            sentTrend.direction === 'up' ? 'bg-emerald-500/15 text-emerald-400'
+                                : sentTrend.direction === 'down' ? 'bg-red-500/15 text-red-400'
+                                : 'bg-zinc-800 text-zinc-400'
+                        ]">
+                            <span v-if="sentTrend.direction === 'up'">▲</span>
+                            <span v-else-if="sentTrend.direction === 'down'">▼</span>
+                            <span v-else>—</span>
+                            <span>{{ sentTrend.pct.toFixed(0) }}%</span>
+                        </span>
+                        <span class="text-xs text-zinc-500">{{ rangeLabel(range) }}</span>
+                    </div>
+                </div>
+
+                <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
+                    <p class="text-xs text-zinc-500 uppercase tracking-wide">Failed</p>
+                    <p class="text-3xl font-bold mt-2 tabular-nums" :class="overview.total_failed > 0 ? 'text-red-400' : 'text-white'">{{ overview.total_failed }}</p>
+                    <div v-if="failedTrend" class="mt-3 flex items-center gap-1.5">
+                        <span :class="[
+                            'inline-flex items-center gap-0.5 text-xs font-medium px-1.5 py-0.5 rounded',
+                            failedTrend.direction === 'down' ? 'bg-emerald-500/15 text-emerald-400'
+                                : failedTrend.direction === 'up' ? 'bg-red-500/15 text-red-400'
+                                : 'bg-zinc-800 text-zinc-400'
+                        ]">
+                            <span v-if="failedTrend.direction === 'up'">▲</span>
+                            <span v-else-if="failedTrend.direction === 'down'">▼</span>
+                            <span v-else>—</span>
+                            <span>{{ failedTrend.pct.toFixed(0) }}%</span>
+                        </span>
+                        <span class="text-xs text-zinc-500">{{ rangeLabel(range) }}</span>
+                    </div>
+                </div>
+
+                <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
+                    <p class="text-xs text-zinc-500 uppercase tracking-wide">Opened</p>
+                    <p class="text-3xl font-bold text-white mt-2 tabular-nums">{{ overview.total_opened }}</p>
+                    <div v-if="openedTrend" class="mt-3 flex items-center gap-1.5">
+                        <span :class="[
+                            'inline-flex items-center gap-0.5 text-xs font-medium px-1.5 py-0.5 rounded',
+                            openedTrend.direction === 'up' ? 'bg-emerald-500/15 text-emerald-400'
+                                : openedTrend.direction === 'down' ? 'bg-red-500/15 text-red-400'
+                                : 'bg-zinc-800 text-zinc-400'
+                        ]">
+                            <span v-if="openedTrend.direction === 'up'">▲</span>
+                            <span v-else-if="openedTrend.direction === 'down'">▼</span>
+                            <span v-else>—</span>
+                            <span>{{ openedTrend.pct.toFixed(0) }}%</span>
+                        </span>
+                        <span class="text-xs text-zinc-500">{{ rangeLabel(range) }}</span>
+                    </div>
+                </div>
+
+                <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
+                    <p class="text-xs text-zinc-500 uppercase tracking-wide">Open rate</p>
+                    <p class="text-3xl font-bold text-white mt-2 tabular-nums">{{ fmtPct(overview.open_rate_pct) }}</p>
+                    <div v-if="openRateTrend" class="mt-3 flex items-center gap-1.5">
+                        <span :class="[
+                            'inline-flex items-center gap-0.5 text-xs font-medium px-1.5 py-0.5 rounded',
+                            openRateTrend.direction === 'up' ? 'bg-emerald-500/15 text-emerald-400'
+                                : openRateTrend.direction === 'down' ? 'bg-red-500/15 text-red-400'
+                                : 'bg-zinc-800 text-zinc-400'
+                        ]">
+                            <span v-if="openRateTrend.direction === 'up'">▲</span>
+                            <span v-else-if="openRateTrend.direction === 'down'">▼</span>
+                            <span v-else>—</span>
+                            <span>{{ openRateTrend.pct.toFixed(0) }}%</span>
+                        </span>
+                        <span class="text-xs text-zinc-500">{{ rangeLabel(range) }}</span>
+                    </div>
+                </div>
+            </div>
+
+            <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
+                <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-6 lg:col-span-2">
+                    <h2 class="text-sm font-semibold text-white mb-1">Conversion funnel</h2>
+                    <p class="text-xs text-zinc-500 mb-5">Send → delivered → opened, last {{ overview.range_days }} days</p>
+
+                    <div v-if="totalSendsCurrent === 0" class="text-center text-sm text-zinc-500 py-8">
+                        No sends in this range yet.
+                    </div>
+                    <div v-else class="space-y-3">
+                        <div>
+                            <div class="flex items-baseline justify-between mb-1.5">
+                                <span class="text-sm text-zinc-300">Sent</span>
+                                <span class="text-sm text-white tabular-nums font-medium">{{ totalSendsCurrent }}</span>
+                            </div>
+                            <div class="h-7 rounded-md bg-gradient-to-r from-zinc-700 to-zinc-600" style="width: 100%"></div>
+                        </div>
+                        <div>
+                            <div class="flex items-baseline justify-between mb-1.5">
+                                <span class="text-sm text-zinc-300">Delivered <span class="text-zinc-500 ml-1">{{ fmtPct(overview.deliverability_pct) }}</span></span>
+                                <span class="text-sm text-white tabular-nums font-medium">{{ overview.total_sent }}</span>
+                            </div>
+                            <div class="h-7 rounded-md bg-gradient-to-r from-emerald-600 to-emerald-500"
+                                :style="{ width: (overview.deliverability_pct) + '%' }"></div>
+                        </div>
+                        <div>
+                            <div class="flex items-baseline justify-between mb-1.5">
+                                <span class="text-sm text-zinc-300">Opened <span class="text-zinc-500 ml-1">{{ fmtPct(overview.open_rate_pct) }}</span></span>
+                                <span class="text-sm text-white tabular-nums font-medium">{{ overview.total_opened }}</span>
+                            </div>
+                            <div class="h-7 rounded-md bg-gradient-to-r from-sky-600 to-sky-400"
+                                :style="{ width: ((overview.total_opened / Math.max(totalSendsCurrent, 1)) * 100) + '%' }"></div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-6">
+                    <h2 class="text-sm font-semibold text-white mb-1">Insights</h2>
+                    <p class="text-xs text-zinc-500 mb-4">Auto-generated from your data</p>
+                    <ul v-if="insights.length > 0" class="space-y-3">
+                        <li v-for="(it, idx) in insights" :key="idx" class="flex gap-2.5 text-sm">
+                            <span class="mt-0.5 inline-block w-1.5 h-1.5 rounded-full flex-shrink-0" :class="{
+                                'bg-emerald-400': it.tone === 'good',
+                                'bg-amber-400': it.tone === 'warn',
+                                'bg-sky-400': it.tone === 'info'
+                            }"></span>
+                            <span class="text-zinc-300 leading-snug">{{ it.text }}</span>
+                        </li>
+                    </ul>
+                    <p v-else class="text-sm text-zinc-500">No insights yet.</p>
+                </div>
+            </div>
+
+            <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-6 mb-6">
+                <div class="flex items-baseline justify-between mb-5">
+                    <div>
+                        <h2 class="text-sm font-semibold text-white">Opens over time</h2>
+                        <p class="text-xs text-zinc-500 mt-0.5">last {{ overview.range_days }} days</p>
+                    </div>
+                </div>
+
+                <div v-if="opensByDay.length === 0" class="text-center text-sm text-zinc-500 py-12">
+                    No opens yet in this range.
+                </div>
+
+                <div v-else>
+                    <svg :viewBox="`0 0 ${chart.width} ${chart.height}`" class="w-full h-48 overflow-visible">
+                        <defs>
+                            <linearGradient id="opensGradient" x1="0" y1="0" x2="0" y2="1">
+                                <stop offset="0%" stop-color="rgb(16, 185, 129)" stop-opacity="0.45" />
+                                <stop offset="100%" stop-color="rgb(16, 185, 129)" stop-opacity="0" />
+                            </linearGradient>
+                        </defs>
+                        <line v-for="g in [0.25, 0.5, 0.75]" :key="g" x1="0" :x2="chart.width"
+                            :y1="g * chart.height" :y2="g * chart.height" stroke="rgb(63, 63, 70)" stroke-width="0.5" stroke-dasharray="3 4" />
+                        <path :d="chart.areaPath" fill="url(#opensGradient)" />
+                        <path :d="chart.linePath" fill="none" stroke="rgb(16, 185, 129)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                        <g v-for="p in chart.points" :key="p.day" class="group">
+                            <circle :cx="p.x" :cy="p.y" r="3" fill="rgb(16, 185, 129)"
+                                stroke="rgb(24, 24, 27)" stroke-width="2"
+                                class="opacity-0 group-hover:opacity-100 transition" />
+                            <rect :x="p.x - 18" y="0" width="36" :height="chart.height" fill="transparent"
+                                class="cursor-pointer">
+                                <title>{{ p.day }}: {{ p.opens }} opens</title>
+                            </rect>
+                        </g>
+                    </svg>
+                    <div class="flex justify-between text-[10px] text-zinc-500 mt-1 px-1">
+                        <span v-for="(p, i) in chart.points" :key="p.day"
+                            v-show="chart.points.length <= 14 || i % Math.ceil(chart.points.length / 8) === 0">
+                            {{ fmtDay(p.day) }}
+                        </span>
+                    </div>
+                </div>
+            </div>
+
+            <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+                <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-6">
+                    <h2 class="text-sm font-semibold text-white mb-1">Send status</h2>
+                    <p class="text-xs text-zinc-500 mb-5">Sent vs failed</p>
+                    <div v-if="statusDonut.total === 0" class="text-center text-sm text-zinc-500 py-8">
+                        No sends yet.
+                    </div>
+                    <div v-else class="flex items-center gap-5">
+                        <svg viewBox="0 0 100 100" class="w-28 h-28 -rotate-90">
+                            <circle cx="50" cy="50" r="40" fill="none" stroke="rgb(239, 68, 68)" stroke-width="14" />
+                            <circle cx="50" cy="50" r="40" fill="none" stroke="rgb(16, 185, 129)" stroke-width="14"
+                                pathLength="100"
+                                :stroke-dasharray="`${statusDonut.sentPct} 100`" />
+                            <circle cx="50" cy="50" r="28" fill="rgb(24, 24, 27)" />
+                        </svg>
+                        <div class="space-y-2 flex-1">
+                            <div class="flex items-center gap-2">
+                                <span class="w-2.5 h-2.5 rounded-full bg-emerald-500"></span>
+                                <span class="text-sm text-zinc-300 flex-1">Sent</span>
+                                <span class="text-sm text-white tabular-nums">{{ statusDonut.sent }}</span>
+                            </div>
+                            <div class="flex items-center gap-2">
+                                <span class="w-2.5 h-2.5 rounded-full bg-red-500"></span>
+                                <span class="text-sm text-zinc-300 flex-1">Failed</span>
+                                <span class="text-sm text-white tabular-nums">{{ statusDonut.failed }}</span>
+                            </div>
+                            <div class="pt-2 border-t border-zinc-800 mt-2">
+                                <div class="flex items-baseline justify-between">
+                                    <span class="text-xs text-zinc-500 uppercase tracking-wide">Active subs</span>
+                                    <span class="text-sm text-white tabular-nums font-medium">{{ overview.active_subscribers }}</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-6 lg:col-span-2">
+                    <h2 class="text-sm font-semibold text-white mb-1">Top templates</h2>
+                    <p class="text-xs text-zinc-500 mb-4">Most-used templates this period</p>
+                    <div v-if="topTemplates.length === 0" class="text-center text-sm text-zinc-500 py-8">
+                        No template sends recorded yet.
+                    </div>
+                    <ul v-else class="space-y-3">
+                        <li v-for="t in topTemplates" :key="t.template_id">
+                            <div class="flex items-baseline justify-between mb-1">
+                                <span class="text-sm text-white truncate pr-2">{{ t.name }}</span>
+                                <span class="text-sm text-zinc-300 tabular-nums">{{ t.sends }}</span>
+                            </div>
+                            <div class="h-1.5 rounded-full bg-zinc-800 overflow-hidden">
+                                <div class="h-full bg-gradient-to-r from-emerald-500 to-sky-500 rounded-full"
+                                    :style="{ width: ((t.sends / maxTopSends) * 100) + '%' }"></div>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>

--- a/frontend/src/views/project/AnalyticsSection.vue
+++ b/frontend/src/views/project/AnalyticsSection.vue
@@ -3,25 +3,35 @@ import { ref, onMounted, computed } from 'vue'
 import { api } from '@/api/client'
 import type { Project } from '@/stores/projects'
 
-interface OpenBucket { day: string; opens: number }
+interface OpenBucket { bucket: string; opens: number }
 interface TemplateStat { template_id: string; name: string; sends: number }
 interface StatusBucket { status: string; count: number }
+interface LinkStat { url: string; clicks: number }
 interface PeriodMetrics {
     total_sent: number
     total_failed: number
     total_opened: number
+    total_clicked: number
     deliverability_pct: number
     open_rate_pct: number
+    click_rate_pct: number
 }
 interface Overview {
+    from: string
+    to: string
+    granularity: 'hour' | 'day' | 'week' | 'month'
     range_days: number
     total_sent: number
     total_failed: number
     total_opened: number
+    total_clicked: number
     deliverability_pct: number
     open_rate_pct: number
-    opens_by_day: OpenBucket[] | null
+    click_rate_pct: number
+    click_to_open_pct: number
+    opens_series: OpenBucket[] | null
     top_templates: TemplateStat[] | null
+    top_clicked_links: LinkStat[] | null
     active_subscribers: number
     sends_by_status: StatusBucket[] | null
     previous: PeriodMetrics
@@ -32,10 +42,42 @@ const props = defineProps<{ project: Project }>()
 const overview = ref<Overview | null>(null)
 const loading = ref(true)
 const errorState = ref<'none' | 'paywall' | 'generic'>('none')
-const range = ref(30)
+type Preset = '24h' | '7d' | '30d' | '90d' | '1y' | 'custom'
 
-const opensByDay = computed(() => overview.value?.opens_by_day ?? [])
+const preset = ref<Preset>('30d')
+const customFrom = ref('')
+const customTo = ref('')
+const showCustomPopover = ref(false)
+const fromISO = ref('')
+const toISO = ref('')
+
+const PRESETS: { value: Preset; label: string }[] = [
+    { value: '24h', label: '24h' },
+    { value: '7d', label: '7d' },
+    { value: '30d', label: '30d' },
+    { value: '90d', label: '90d' },
+    { value: '1y', label: '1y' },
+]
+
+function presetWindow(p: Preset): { from: Date; to: Date } | null {
+    const now = new Date()
+    const to = now
+    let from: Date
+    switch (p) {
+        case '24h': from = new Date(now.getTime() - 24 * 60 * 60 * 1000); break
+        case '7d':  from = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000); break
+        case '30d': from = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000); break
+        case '90d': from = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000); break
+        case '1y':  from = new Date(now.getTime() - 365 * 24 * 60 * 60 * 1000); break
+        default: return null
+    }
+    return { from, to }
+}
+
+const opensByDay = computed(() => overview.value?.opens_series ?? [])
 const topTemplates = computed(() => overview.value?.top_templates ?? [])
+const topClickedLinks = computed(() => overview.value?.top_clicked_links ?? [])
+const maxLinkClicks = computed(() => topClickedLinks.value.reduce((m, l) => Math.max(m, l.clicks), 0) || 1)
 
 const totalSendsCurrent = computed(() => {
     const o = overview.value
@@ -48,7 +90,7 @@ const maxTopSends = computed(() => topTemplates.value.reduce((m, t) => Math.max(
 interface ChartGeometry {
     width: number
     height: number
-    points: { x: number; y: number; day: string; opens: number }[]
+    points: { x: number; y: number; bucket: string; opens: number }[]
     linePath: string
     areaPath: string
 }
@@ -64,7 +106,7 @@ const chart = computed<ChartGeometry>(() => {
     const points = data.map((d, i) => ({
         x: data.length === 1 ? w / 2 : i * xStep,
         y: h - (d.opens / max) * (h - 24) - 12,
-        day: d.day,
+        bucket: d.bucket,
         opens: d.opens,
     }))
 
@@ -127,7 +169,9 @@ function trend(current: number, previous: number, invertGood = false): Trend {
 const sentTrend = computed(() => overview.value ? trend(overview.value.total_sent, overview.value.previous.total_sent) : null)
 const failedTrend = computed(() => overview.value ? trend(overview.value.total_failed, overview.value.previous.total_failed, true) : null)
 const openedTrend = computed(() => overview.value ? trend(overview.value.total_opened, overview.value.previous.total_opened) : null)
+const clickedTrend = computed(() => overview.value ? trend(overview.value.total_clicked, overview.value.previous.total_clicked) : null)
 const openRateTrend = computed(() => overview.value ? trend(overview.value.open_rate_pct, overview.value.previous.open_rate_pct) : null)
+const clickRateTrend = computed(() => overview.value ? trend(overview.value.click_rate_pct, overview.value.previous.click_rate_pct) : null)
 
 const insights = computed(() => {
     const o = overview.value
@@ -137,11 +181,13 @@ const insights = computed(() => {
     if (opensByDay.value.length > 0) {
         const top = [...opensByDay.value].sort((a, b) => b.opens - a.opens)[0]
         if (top && top.opens > 0) {
-            const date = new Date(top.day + 'T00:00:00')
-            const weekday = date.toLocaleDateString('en-US', { weekday: 'long' })
+            const date = new Date(top.bucket)
+            const weekday = date.toLocaleDateString('en-US', { weekday: 'long', timeZone: 'UTC' })
+            const day = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' })
+            const noun = o.granularity === 'hour' ? 'hour' : (o.granularity === 'week' ? 'week' : (o.granularity === 'month' ? 'month' : 'day'))
             items.push({
                 tone: 'info',
-                text: `Best day this period: ${weekday} ${top.day.slice(5)} with ${top.opens} open${top.opens === 1 ? '' : 's'}.`,
+                text: `Best ${noun} this period: ${weekday} ${day} with ${top.opens} open${top.opens === 1 ? '' : 's'}.`,
             })
         }
     }
@@ -193,7 +239,8 @@ async function load() {
     loading.value = true
     errorState.value = 'none'
     try {
-        const url = `/projects/${props.project.id}/analytics/overview?range_days=${range.value}`
+        const params = new URLSearchParams({ from: fromISO.value, to: toISO.value })
+        const url = `/projects/${props.project.id}/analytics/overview?${params.toString()}`
         overview.value = await api<Overview>(url)
     } catch (e) {
         const msg = e instanceof Error ? e.message : ''
@@ -204,8 +251,29 @@ async function load() {
     }
 }
 
-function setRange(days: number) {
-    range.value = days
+function applyPreset(p: Preset) {
+    if (p === 'custom') {
+        showCustomPopover.value = true
+        return
+    }
+    preset.value = p
+    showCustomPopover.value = false
+    const w = presetWindow(p)
+    if (!w) return
+    fromISO.value = w.from.toISOString()
+    toISO.value = w.to.toISOString()
+    load()
+}
+
+function applyCustom() {
+    if (!customFrom.value || !customTo.value) return
+    const from = new Date(customFrom.value + 'T00:00:00Z')
+    const to = new Date(customTo.value + 'T23:59:59Z')
+    if (!(to > from)) return
+    preset.value = 'custom'
+    fromISO.value = from.toISOString()
+    toISO.value = to.toISOString()
+    showCustomPopover.value = false
     load()
 }
 
@@ -214,16 +282,32 @@ function fmtPct(n: number | undefined) {
     return `${n.toFixed(1)}%`
 }
 
-function fmtDay(iso: string) {
-    const [, m, d] = iso.split('-')
-    return `${d}/${m}`
+function fmtBucket(iso: string, granularity: string) {
+    const d = new Date(iso)
+    if (granularity === 'hour') {
+        return d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false, timeZone: 'UTC' })
+    }
+    if (granularity === 'month') {
+        return d.toLocaleDateString('en-US', { month: 'short', year: '2-digit', timeZone: 'UTC' })
+    }
+    return d.toLocaleDateString('en-US', { day: '2-digit', month: 'short', timeZone: 'UTC' })
 }
 
-function rangeLabel(days: number) {
-    return `vs previous ${days}d`
+function fmtRange() {
+    if (!overview.value) return ''
+    const f = new Date(overview.value.from)
+    const t = new Date(overview.value.to)
+    const fStr = f.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+    const tStr = t.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+    if (fStr === tStr) return fStr
+    return `${fStr} → ${tStr}`
 }
 
-onMounted(load)
+function rangeLabel() {
+    return `vs previous ${preset.value === 'custom' ? 'period' : preset.value}`
+}
+
+onMounted(() => applyPreset(preset.value))
 </script>
 
 <template>
@@ -236,11 +320,33 @@ onMounted(load)
                 </div>
                 <p class="text-sm text-zinc-500 mt-1">Send performance and engagement trends</p>
             </div>
-            <div class="flex gap-1 bg-zinc-900 border border-zinc-800 rounded-lg p-1">
-                <button v-for="r in [7, 30, 90]" :key="r" @click="setRange(r)" :class="[
-                    'px-3 py-1 text-sm rounded-md transition cursor-pointer',
-                    range === r ? 'bg-zinc-800 text-white' : 'text-zinc-400 hover:text-white'
-                ]">{{ r }}d</button>
+            <div class="relative">
+                <div class="flex gap-1 bg-zinc-900 border border-zinc-800 rounded-lg p-1">
+                    <button v-for="p in PRESETS" :key="p.value" @click="applyPreset(p.value)" :class="[
+                        'px-3 py-1 text-sm rounded-md transition cursor-pointer',
+                        preset === p.value ? 'bg-zinc-800 text-white' : 'text-zinc-400 hover:text-white'
+                    ]">{{ p.label }}</button>
+                    <button @click="applyPreset('custom')" :class="[
+                        'px-3 py-1 text-sm rounded-md transition cursor-pointer',
+                        preset === 'custom' ? 'bg-zinc-800 text-white' : 'text-zinc-400 hover:text-white'
+                    ]">Custom</button>
+                </div>
+                <div v-if="showCustomPopover"
+                    class="absolute right-0 top-full mt-2 z-20 bg-zinc-900 border border-zinc-800 rounded-lg shadow-xl p-4 w-72">
+                    <p class="text-xs font-semibold text-zinc-400 uppercase tracking-wide mb-3">Custom range</p>
+                    <label class="block text-xs text-zinc-500 mb-1">From</label>
+                    <input v-model="customFrom" type="date"
+                        class="w-full mb-3 px-3 py-2 text-sm bg-zinc-950 border border-zinc-800 rounded-md text-white focus:border-zinc-600 focus:outline-none" />
+                    <label class="block text-xs text-zinc-500 mb-1">To</label>
+                    <input v-model="customTo" type="date"
+                        class="w-full mb-4 px-3 py-2 text-sm bg-zinc-950 border border-zinc-800 rounded-md text-white focus:border-zinc-600 focus:outline-none" />
+                    <div class="flex gap-2">
+                        <button @click="showCustomPopover = false"
+                            class="flex-1 px-3 py-1.5 text-sm rounded-md text-zinc-300 hover:bg-zinc-800 transition cursor-pointer">Cancel</button>
+                        <button @click="applyCustom" :disabled="!customFrom || !customTo"
+                            class="flex-1 px-3 py-1.5 text-sm rounded-md bg-white text-zinc-950 hover:bg-zinc-200 transition cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed">Apply</button>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -266,7 +372,7 @@ onMounted(load)
         </div>
 
         <div v-else-if="overview">
-            <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+            <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 mb-6">
                 <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
                     <p class="text-xs text-zinc-500 uppercase tracking-wide">Sent</p>
                     <p class="text-3xl font-bold text-white mt-2 tabular-nums">{{ overview.total_sent }}</p>
@@ -282,7 +388,7 @@ onMounted(load)
                             <span v-else>—</span>
                             <span>{{ sentTrend.pct.toFixed(0) }}%</span>
                         </span>
-                        <span class="text-xs text-zinc-500">{{ rangeLabel(range) }}</span>
+                        <span class="text-xs text-zinc-500">{{ rangeLabel() }}</span>
                     </div>
                 </div>
 
@@ -301,7 +407,7 @@ onMounted(load)
                             <span v-else>—</span>
                             <span>{{ failedTrend.pct.toFixed(0) }}%</span>
                         </span>
-                        <span class="text-xs text-zinc-500">{{ rangeLabel(range) }}</span>
+                        <span class="text-xs text-zinc-500">{{ rangeLabel() }}</span>
                     </div>
                 </div>
 
@@ -320,7 +426,26 @@ onMounted(load)
                             <span v-else>—</span>
                             <span>{{ openedTrend.pct.toFixed(0) }}%</span>
                         </span>
-                        <span class="text-xs text-zinc-500">{{ rangeLabel(range) }}</span>
+                        <span class="text-xs text-zinc-500">{{ rangeLabel() }}</span>
+                    </div>
+                </div>
+
+                <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
+                    <p class="text-xs text-zinc-500 uppercase tracking-wide">Clicked</p>
+                    <p class="text-3xl font-bold text-white mt-2 tabular-nums">{{ overview.total_clicked }}</p>
+                    <div v-if="clickedTrend" class="mt-3 flex items-center gap-1.5">
+                        <span :class="[
+                            'inline-flex items-center gap-0.5 text-xs font-medium px-1.5 py-0.5 rounded',
+                            clickedTrend.direction === 'up' ? 'bg-emerald-500/15 text-emerald-400'
+                                : clickedTrend.direction === 'down' ? 'bg-red-500/15 text-red-400'
+                                : 'bg-zinc-800 text-zinc-400'
+                        ]">
+                            <span v-if="clickedTrend.direction === 'up'">▲</span>
+                            <span v-else-if="clickedTrend.direction === 'down'">▼</span>
+                            <span v-else>—</span>
+                            <span>{{ clickedTrend.pct.toFixed(0) }}%</span>
+                        </span>
+                        <span class="text-xs text-zinc-500">{{ rangeLabel() }}</span>
                     </div>
                 </div>
 
@@ -339,7 +464,26 @@ onMounted(load)
                             <span v-else>—</span>
                             <span>{{ openRateTrend.pct.toFixed(0) }}%</span>
                         </span>
-                        <span class="text-xs text-zinc-500">{{ rangeLabel(range) }}</span>
+                        <span class="text-xs text-zinc-500">{{ rangeLabel() }}</span>
+                    </div>
+                </div>
+
+                <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
+                    <p class="text-xs text-zinc-500 uppercase tracking-wide">Click rate</p>
+                    <p class="text-3xl font-bold text-white mt-2 tabular-nums">{{ fmtPct(overview.click_rate_pct) }}</p>
+                    <div v-if="clickRateTrend" class="mt-3 flex items-center gap-1.5">
+                        <span :class="[
+                            'inline-flex items-center gap-0.5 text-xs font-medium px-1.5 py-0.5 rounded',
+                            clickRateTrend.direction === 'up' ? 'bg-emerald-500/15 text-emerald-400'
+                                : clickRateTrend.direction === 'down' ? 'bg-red-500/15 text-red-400'
+                                : 'bg-zinc-800 text-zinc-400'
+                        ]">
+                            <span v-if="clickRateTrend.direction === 'up'">▲</span>
+                            <span v-else-if="clickRateTrend.direction === 'down'">▼</span>
+                            <span v-else>—</span>
+                            <span>{{ clickRateTrend.pct.toFixed(0) }}%</span>
+                        </span>
+                        <span class="text-xs text-zinc-500">{{ rangeLabel() }}</span>
                     </div>
                 </div>
             </div>
@@ -347,7 +491,7 @@ onMounted(load)
             <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
                 <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-6 lg:col-span-2">
                     <h2 class="text-sm font-semibold text-white mb-1">Conversion funnel</h2>
-                    <p class="text-xs text-zinc-500 mb-5">Send → delivered → opened, last {{ overview.range_days }} days</p>
+                    <p class="text-xs text-zinc-500 mb-5">Send → delivered → opened, {{ fmtRange() }}</p>
 
                     <div v-if="totalSendsCurrent === 0" class="text-center text-sm text-zinc-500 py-8">
                         No sends in this range yet.
@@ -376,6 +520,14 @@ onMounted(load)
                             <div class="h-7 rounded-md bg-gradient-to-r from-sky-600 to-sky-400"
                                 :style="{ width: ((overview.total_opened / Math.max(totalSendsCurrent, 1)) * 100) + '%' }"></div>
                         </div>
+                        <div>
+                            <div class="flex items-baseline justify-between mb-1.5">
+                                <span class="text-sm text-zinc-300">Clicked <span class="text-zinc-500 ml-1">{{ fmtPct(overview.click_rate_pct) }}</span><span v-if="overview.click_to_open_pct > 0" class="text-zinc-600 ml-2 text-xs">CTOR {{ fmtPct(overview.click_to_open_pct) }}</span></span>
+                                <span class="text-sm text-white tabular-nums font-medium">{{ overview.total_clicked }}</span>
+                            </div>
+                            <div class="h-7 rounded-md bg-gradient-to-r from-fuchsia-600 to-violet-400"
+                                :style="{ width: ((overview.total_clicked / Math.max(totalSendsCurrent, 1)) * 100) + '%' }"></div>
+                        </div>
                     </div>
                 </div>
 
@@ -400,7 +552,7 @@ onMounted(load)
                 <div class="flex items-baseline justify-between mb-5">
                     <div>
                         <h2 class="text-sm font-semibold text-white">Opens over time</h2>
-                        <p class="text-xs text-zinc-500 mt-0.5">last {{ overview.range_days }} days</p>
+                        <p class="text-xs text-zinc-500 mt-0.5">{{ fmtRange() }}</p>
                     </div>
                 </div>
 
@@ -420,26 +572,69 @@ onMounted(load)
                             :y1="g * chart.height" :y2="g * chart.height" stroke="rgb(63, 63, 70)" stroke-width="0.5" stroke-dasharray="3 4" />
                         <path :d="chart.areaPath" fill="url(#opensGradient)" />
                         <path :d="chart.linePath" fill="none" stroke="rgb(16, 185, 129)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                        <g v-for="p in chart.points" :key="p.day" class="group">
+                        <g v-for="p in chart.points" :key="p.bucket" class="group">
                             <circle :cx="p.x" :cy="p.y" r="3" fill="rgb(16, 185, 129)"
                                 stroke="rgb(24, 24, 27)" stroke-width="2"
                                 class="opacity-0 group-hover:opacity-100 transition" />
                             <rect :x="p.x - 18" y="0" width="36" :height="chart.height" fill="transparent"
                                 class="cursor-pointer">
-                                <title>{{ p.day }}: {{ p.opens }} opens</title>
+                                <title>{{ p.bucket }}: {{ p.opens }} opens</title>
                             </rect>
                         </g>
                     </svg>
                     <div class="flex justify-between text-[10px] text-zinc-500 mt-1 px-1">
-                        <span v-for="(p, i) in chart.points" :key="p.day"
+                        <span v-for="(p, i) in chart.points" :key="p.bucket"
                             v-show="chart.points.length <= 14 || i % Math.ceil(chart.points.length / 8) === 0">
-                            {{ fmtDay(p.day) }}
+                            {{ fmtBucket(p.bucket, overview.granularity) }}
                         </span>
                     </div>
                 </div>
             </div>
 
-            <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4">
+                <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-6">
+                    <h2 class="text-sm font-semibold text-white mb-1">Top templates</h2>
+                    <p class="text-xs text-zinc-500 mb-4">Most-used templates this period</p>
+                    <div v-if="topTemplates.length === 0" class="text-center text-sm text-zinc-500 py-8">
+                        No template sends recorded yet.
+                    </div>
+                    <ul v-else class="space-y-3">
+                        <li v-for="t in topTemplates" :key="t.template_id">
+                            <div class="flex items-baseline justify-between mb-1">
+                                <span class="text-sm text-white truncate pr-2">{{ t.name }}</span>
+                                <span class="text-sm text-zinc-300 tabular-nums">{{ t.sends }}</span>
+                            </div>
+                            <div class="h-1.5 rounded-full bg-zinc-800 overflow-hidden">
+                                <div class="h-full bg-gradient-to-r from-emerald-500 to-sky-500 rounded-full"
+                                    :style="{ width: ((t.sends / maxTopSends) * 100) + '%' }"></div>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+
+                <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-6">
+                    <h2 class="text-sm font-semibold text-white mb-1">Top clicked links</h2>
+                    <p class="text-xs text-zinc-500 mb-4">Most-clicked links this period</p>
+                    <div v-if="topClickedLinks.length === 0" class="text-center text-sm text-zinc-500 py-8">
+                        No clicks recorded yet.
+                    </div>
+                    <ul v-else class="space-y-3">
+                        <li v-for="l in topClickedLinks" :key="l.url">
+                            <div class="flex items-baseline justify-between mb-1 gap-2">
+                                <a :href="l.url" target="_blank" rel="noopener noreferrer"
+                                    class="text-sm text-white truncate hover:text-sky-400 transition" :title="l.url">{{ l.url }}</a>
+                                <span class="text-sm text-zinc-300 tabular-nums flex-shrink-0">{{ l.clicks }}</span>
+                            </div>
+                            <div class="h-1.5 rounded-full bg-zinc-800 overflow-hidden">
+                                <div class="h-full bg-gradient-to-r from-fuchsia-500 to-violet-500 rounded-full"
+                                    :style="{ width: ((l.clicks / maxLinkClicks) * 100) + '%' }"></div>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+
+            <div class="grid grid-cols-1 gap-4">
                 <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-6">
                     <h2 class="text-sm font-semibold text-white mb-1">Send status</h2>
                     <p class="text-xs text-zinc-500 mb-5">Sent vs failed</p>
@@ -475,25 +670,6 @@ onMounted(load)
                     </div>
                 </div>
 
-                <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-6 lg:col-span-2">
-                    <h2 class="text-sm font-semibold text-white mb-1">Top templates</h2>
-                    <p class="text-xs text-zinc-500 mb-4">Most-used templates this period</p>
-                    <div v-if="topTemplates.length === 0" class="text-center text-sm text-zinc-500 py-8">
-                        No template sends recorded yet.
-                    </div>
-                    <ul v-else class="space-y-3">
-                        <li v-for="t in topTemplates" :key="t.template_id">
-                            <div class="flex items-baseline justify-between mb-1">
-                                <span class="text-sm text-white truncate pr-2">{{ t.name }}</span>
-                                <span class="text-sm text-zinc-300 tabular-nums">{{ t.sends }}</span>
-                            </div>
-                            <div class="h-1.5 rounded-full bg-zinc-800 overflow-hidden">
-                                <div class="h-full bg-gradient-to-r from-emerald-500 to-sky-500 rounded-full"
-                                    :style="{ width: ((t.sends / maxTopSends) * 100) + '%' }"></div>
-                            </div>
-                        </li>
-                    </ul>
-                </div>
             </div>
         </div>
     </div>

--- a/frontend/src/views/project/ProjectView.vue
+++ b/frontend/src/views/project/ProjectView.vue
@@ -33,8 +33,8 @@ const navItems = [
 ]
 
 const proItems = [
-    { name: 'Analytics' },
-    { name: 'Webhooks' },
+    { name: 'Analytics', route: 'project-analytics' },
+    { name: 'Webhooks', route: null },
 ]
 
 onMounted(loadProject)
@@ -68,10 +68,24 @@ onMounted(loadProject)
 
                     <div class="pt-4 mt-4 border-t border-zinc-800">
                         <p class="px-3 text-xs text-zinc-500 uppercase tracking-wide mb-2">Pro</p>
-                        <span v-for="item in proItems" :key="item.name"
-                            class="block px-3 py-2 text-sm rounded-lg text-zinc-500 cursor-not-allowed">
-                            {{ item.name }}
-                        </span>
+                        <template v-for="item in proItems" :key="item.name">
+                            <RouterLink v-if="item.route"
+                                :to="{ name: item.route, params: { id: projectId } }"
+                                :class="[
+                                    'flex items-center justify-between px-3 py-2 text-sm rounded-lg transition',
+                                    route.name === item.route
+                                        ? 'bg-zinc-800 text-white'
+                                        : 'text-zinc-400 hover:text-white hover:bg-zinc-800'
+                                ]">
+                                <span>{{ item.name }}</span>
+                                <span class="text-[10px] font-semibold tracking-wider uppercase px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400 border border-amber-500/30">Pro</span>
+                            </RouterLink>
+                            <span v-else
+                                class="flex items-center justify-between px-3 py-2 text-sm rounded-lg text-zinc-500 cursor-not-allowed">
+                                <span>{{ item.name }}</span>
+                                <span class="text-[10px] tracking-wider uppercase text-zinc-600">soon</span>
+                            </span>
+                        </template>
                     </div>
                 </nav>
             </aside>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,7 +5,6 @@ import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 import tailwindcss from '@tailwindcss/vite'
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [
     vue(),
@@ -15,6 +14,22 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))
+    },
+  },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+      '/unsubscribe': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+      '/t': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
     },
   },
 })


### PR DESCRIPTION
Brings the Pro Analytics dashboard to life by adding the missing event signal (clicks), wiring it into the UI alongside open tracking, and giving every send path the same tracking + log handling so the numbers are consistent. Also adds dev-quality fixes that surfaced during the build (SMTP timeouts, dark-mode date inputs, session-expiry redirect).

This PR supersedes the standalone `feat/pro-analytics-ui` branch — it has been merged in here so the Analytics dashboard arrives in the same drop as the click data it consumes.

## Click tracking (the headline feature)

- Migration adds `clicked_at` on `email_logs` and a separate `email_clicks` table (one row per click, with url, hash, user-agent and IP).
- New service helpers HMAC-sign `/c/{logID}/{base64-url}.{sig}` and rewrite every absolute http(s) `<a href>` in outgoing email bodies before SMTP. Mailto, tel, anchors, and existing tracker URLs are skipped.
- New `GET /c/{logID}/{payload}` handler verifies the sig, records a row in `email_clicks`, flips the parent log's `clicked_at` on first click, and 302-redirects.
- All four send paths (SendToSubscriber, Broadcast, SendDirect, SendWithTemplate) now go through a single `trackAndSend` helper. Side effects:
  - Open + click tracking now apply to every send, not just SendToSubscriber.
  - Failed sends produce one log row, not two — fixes a pre-existing dual-insert bug that double-counted failures in stats.

## Pro Analytics UI

- New `AnalyticsSection.vue` mounted from the project sidebar, gated behind a Pro badge. Falls back to a paywall card if the backend returns 402.
- Hero metrics: Sent / Failed / Opened / Clicked / Open rate / Click rate, each with a vs-previous-period trend pill (failed inverted so 'fewer failures' reads as a win).
- Conversion funnel: Sent → Delivered → Opened → Clicked, with proportional gradient bars and click-to-open ratio.
- Auto-generated insights panel adapted to the bucket granularity ('best day', 'best hour', 'best week', 'best month').
- Smooth area chart for opens-over-time, inline SVG (Catmull-Rom-to-Bezier path) with gradient fill and hover tooltips. No charting dependency.
- Donut chart for sent-vs-failed status.
- Top templates and Top clicked links lists with mini progress bars.

## Custom date ranges

- The hard-coded 7d/30d/90d picker is replaced with 24h, 7d, 30d, 90d, 1y, plus a Custom popover with native date inputs.
- The picked window is sent as `?from=ISO&to=ISO` and the backend (Pro) auto-picks bucket granularity (hour / day / week / month) from the duration.
- The chart, labels, and insight copy adapt to the chosen bucket.

## Quality fixes that came with the build

- **SMTP timeouts.** Outgoing SMTP gets a 10s connect deadline and 30s session deadline, replacing the kernel default that hung Test Connection for ~75s on unreachable hosts.
- **Friendlier SMTP errors.** Connect timeouts now explain the residential-ISP block possibility, refused connections call out the wrong port, and DNS failures call out typos. Error copy reads like a troubleshooting guide.
- **Mailpit dev profile.** `docker-compose.yml` ships a Mailpit service under the `mail` profile so contributors stuck behind ISP-blocked SMTP can still test the full send path locally.
- **Session-expiry redirect.** Token expiry mid-page now triggers an immediate redirect to /login plus a single toast — previously the user stayed on a half-broken screen as buttons silently 401'd. Deduped so racing requests don't fire the toast multiple times.
- **Dark-mode date inputs.** Inverted the native calendar picker icon so it's visible on the zinc background.

## Docs

`docs/guide/smtp.md`, `docs/self-hosting/installation.md` and `docs/self-hosting/troubleshooting.md` all gain explicit notes on the residential-ISP SMTP block and the four available workarounds, so first-time evaluators searching 'SendDock SMTP timeout' land on a concrete answer instead of assuming the product is broken.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` all pass on Core
- `vue-tsc --noEmit` clean on the frontend
- Vitepress builds the docs without errors
- Pro analytics endpoint round-trips against the new schema (verified locally with seed data)