### PR TITLE
release: v0.5.1

### DIFF
--- a/backend/internal/version/version.go
+++ b/backend/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var Version = "0.5.0"
+var Version = "0.5.1"

--- a/docs/self-hosting/installation.md
+++ b/docs/self-hosting/installation.md
@@ -87,7 +87,7 @@ Open `http://your-domain.com` (or `http://localhost:8080` for a local test) and 
 | empty (cloud mode) | Free tier — Core features only (subscribers, templates, transactional sends, broadcasts, campaigns, BYO SMTP, click & open tracking). |
 | valid | Pro tier — unlocks the [Analytics dashboard](/guide/analytics) and [Webhooks management](/guide/webhooks). |
 
-The image is the same in both cases. The license key, validated against a hosted endpoint, toggles the gated routes. Read more in the [pricing page](https://senddock.com/pricing).
+The image is the same in both cases. The license key, validated against a hosted endpoint, toggles the gated routes. Read more in the [pricing page](https://senddock.dev/pricing).
 
 ::: warning Self-hosted with empty license unlocks everything
 This is intentional — local development should never need a license. If you self-host an instance that other people will use, set a real `SENDDOCK_LICENSE_KEY` (or accept that Pro features are free for those users). The "empty key = unlocked" behavior only fires when `DEPLOYMENT_MODE=self-hosted`, which is the default.

--- a/docs/self-hosting/installation.md
+++ b/docs/self-hosting/installation.md
@@ -100,7 +100,7 @@ This is intentional — local development should never need a license. If you se
 ```yaml
 services:
   senddock:
-    image: ghcr.io/arkhe-systems/senddock:0.5.0
+    image: ghcr.io/arkhe-systems/senddock:0.5.1
 ```
 
 See available tags on [GHCR](https://github.com/Arkhe-Systems/senddock/pkgs/container/senddock). Only versioned tags (`X.Y.Z`, `X.Y`, `X`) and `:latest` are public — pre-release builds (`:dev`) live in a separate, private package and are not intended for end users.

--- a/docs/self-hosting/updating.md
+++ b/docs/self-hosting/updating.md
@@ -45,7 +45,7 @@ Pin the version in `docker-compose.yml` to control update timing:
 ```yaml
 services:
   senddock:
-    image: ghcr.io/arkhe-systems/senddock:0.5.0
+    image: ghcr.io/arkhe-systems/senddock:0.5.1
 ```
 
 When you decide to upgrade, edit the tag, then `docker compose pull && docker compose up -d`.

--- a/frontend/src/views/project/AnalyticsSection.vue
+++ b/frontend/src/views/project/AnalyticsSection.vue
@@ -361,7 +361,7 @@ onMounted(() => applyPreset(preset.value))
                 Detailed deliverability metrics, open tracking trends and top-template insights
                 require a SendDock Pro license. Activate one to unlock this section.
             </p>
-            <a href="https://senddock.com/pricing" target="_blank" rel="noopener"
+            <a href="https://senddock.dev/pricing" target="_blank" rel="noopener"
                 class="inline-block px-4 py-2 text-sm font-medium bg-white text-zinc-950 rounded-lg hover:bg-zinc-200 transition">
                 See Pro plans
             </a>

--- a/frontend/src/views/project/WebhooksSection.vue
+++ b/frontend/src/views/project/WebhooksSection.vue
@@ -216,7 +216,7 @@ onMounted(load)
                 Webhook delivery, signed payloads and retries require a SendDock Pro license.
                 Activate one to receive real-time event notifications in your own systems.
             </p>
-            <a href="https://senddock.com/pricing" target="_blank" rel="noopener"
+            <a href="https://senddock.dev/pricing" target="_blank" rel="noopener"
                 class="inline-block px-4 py-2 text-sm font-medium bg-white text-zinc-950 rounded-lg hover:bg-zinc-200 transition">
                 See Pro plans
             </a>


### PR DESCRIPTION
## Patch fixes

- Hide UpdateBadge in cloud deployments (`enabled: false` from /version when DEPLOYMENT_MODE=cloud)
- Render release notes as Markdown via `marked` (was raw `<pre>`)
- Default upgrade command to `docker compose pull && docker compose up -d`; `git pull && ./setup.sh` shown as note for source-build users
- Make the version label always clickable so users on the latest can revisit release notes
- Fix broken pricing links that pointed to `senddock.com/pricing` (the domain doesn't exist) — now `senddock.dev/pricing`

## Test plan
- [x] `go build ./...` passes
- [x] `npm run build` passes
- [x] Cloud mode: badge component does not render
- [x] Self-hosted mode: badge clickable when current; opens "What's in v0.5.1" modal with rendered Markdown