### PR TITLE
release: v0.5.2 — CRITICAL license bypass fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ SendDock is open-core: the open-source binary you can self-host today is fully u
 - Webhooks management UI and REST API (CRUD, pause/resume, deliveries history)
 - Future: team members + roles, SMTP failover, SSO/LDAP, white-label
 
-In **self-hosted** mode an empty `SENDDOCK_LICENSE_KEY` unlocks Pro locally for development. In **cloud** mode it stays locked until a real key is set. See [docs/self-hosting/configuration.md](docs/self-hosting/configuration.md) for the full matrix.
+An empty `SENDDOCK_LICENSE_KEY` keeps Pro locked in any deployment mode — Core stays fully usable for free, Pro requires a license. See [docs/self-hosting/configuration.md](docs/self-hosting/configuration.md) for details.
 
 ## Environment Variables
 
@@ -197,7 +197,7 @@ In **self-hosted** mode an empty `SENDDOCK_LICENSE_KEY` unlocks Pro locally for 
 | `FRONTEND_URL` | Frontend URL for CORS | `http://localhost:5173` |
 | `PUBLIC_URL` | Public URL of the instance, used in unsubscribe and tracking links inside emails | falls back to `FRONTEND_URL` |
 | `DEPLOYMENT_MODE` | `self-hosted` or `cloud` | `self-hosted` |
-| `SENDDOCK_LICENSE_KEY` | Pro license key (Lemon Squeezy). Empty in self-hosted unlocks Pro locally | — |
+| `SENDDOCK_LICENSE_KEY` | Pro license key (Lemon Squeezy). Empty leaves the deployment on the free tier (Core only) | — |
 
 ## License
 

--- a/backend/internal/version/version.go
+++ b/backend/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var Version = "0.5.1"
+var Version = "0.5.2"

--- a/docs/api/webhooks.md
+++ b/docs/api/webhooks.md
@@ -2,7 +2,7 @@
 
 Manage webhook endpoints and inspect their delivery history. Cookie auth required.
 
-In **cloud** mode every endpoint on this page returns `402 Payment Required` (`{"error":"license required for webhooks"}`) when the deployment has no valid `SENDDOCK_LICENSE_KEY`. In **self-hosted** mode an empty license unlocks everything locally — see [Configuration → Pro license](/self-hosting/configuration#pro-license).
+Every endpoint on this page returns `402 Payment Required` (`{"error":"license required for webhooks"}`) when the deployment has no valid `SENDDOCK_LICENSE_KEY`. This applies the same way to self-hosted and cloud — see [Configuration → Pro license](/self-hosting/configuration#pro-license).
 
 For payload format, signature verification, retry policy and event reference, see the [Webhooks guide](/guide/webhooks).
 

--- a/docs/guide/analytics.md
+++ b/docs/guide/analytics.md
@@ -68,8 +68,7 @@ See the [Analytics API reference](/api/analytics) for the full payload schema.
 
 Analytics is gated by `SENDDOCK_LICENSE_KEY`:
 
-- **Self-hosted** with empty license — Pro features are unlocked locally for development. Analytics works.
-- **Self-hosted** with valid license — Pro unlocked.
-- **Cloud** mode (the senddock.dev managed product) requires a valid key. An empty key returns `402 Payment Required` on `/analytics/overview`, which the UI renders as a paywall card linking to pricing.
+- An empty `SENDDOCK_LICENSE_KEY` leaves Pro locked. The Analytics dashboard returns `402 Payment Required`, which the UI renders as a paywall card linking to pricing. This applies to both self-hosted and cloud deployments — Core stays fully usable, Pro requires a license.
+- A valid license unlocks Analytics. The validator caches its last successful result for 24 hours, so brief network blips with Lemon Squeezy don't lock you out.
 
 See [Configuration → Pro license](/self-hosting/configuration#pro-license) for the env var.

--- a/docs/guide/environment.md
+++ b/docs/guide/environment.md
@@ -18,7 +18,7 @@ All configuration is done via environment variables. Copy `.env.example` to `.en
 | `FRONTEND_URL` | Frontend URL for CORS headers | `http://localhost:5173` |
 | `PUBLIC_URL` | Public URL of this instance, used to build unsubscribe and tracking links inside outgoing emails. Leave blank in single-binary deploys to fall back to `FRONTEND_URL`. | _falls back to `FRONTEND_URL`_ |
 | `DEPLOYMENT_MODE` | `self-hosted` or `cloud` | `self-hosted` |
-| `SENDDOCK_LICENSE_KEY` | Pro license key. Validated against Lemon Squeezy. Empty in self-hosted mode unlocks Pro locally for development; empty in cloud mode keeps the deployment on the free tier. See [Pro license](/self-hosting/configuration#pro-license). | — |
+| `SENDDOCK_LICENSE_KEY` | Pro license key. Validated against Lemon Squeezy. Empty leaves the deployment on the free tier (Core only) regardless of `DEPLOYMENT_MODE`. See [Pro license](/self-hosting/configuration#pro-license). | — |
 
 ::: tip Why PUBLIC_URL?
 Outgoing emails contain links like the unsubscribe URL and the open-tracking pixel. SendDock cannot guess what URL recipients will see — it has to be told. In most single-binary deploys (Go binary serves both the API and the SPA), `PUBLIC_URL` and `FRONTEND_URL` are the same value, so you can leave `PUBLIC_URL` blank and only set `FRONTEND_URL`.

--- a/docs/guide/webhooks.md
+++ b/docs/guide/webhooks.md
@@ -237,4 +237,4 @@ If you want to inspect what SendDock is sending without writing a handler, point
 
 Webhook **management** (CRUD endpoints, the UI section) is gated by `SENDDOCK_LICENSE_KEY` in cloud mode. The **dispatcher** runs in Core regardless of license — webhooks created before a license expires keep firing — but new webhooks cannot be created without a valid key.
 
-In **self-hosted** mode an empty key keeps everything unlocked locally, which is the right default for development. See [Configuration → Pro license](/self-hosting/configuration#pro-license).
+An empty `SENDDOCK_LICENSE_KEY` keeps the management UI / API locked regardless of deployment mode — but the Core dispatcher keeps running, so any webhooks created earlier (from a Pro-licensed snapshot) continue firing. See [Configuration → Pro license](/self-hosting/configuration#pro-license).

--- a/docs/self-hosting/configuration.md
+++ b/docs/self-hosting/configuration.md
@@ -81,12 +81,13 @@ SENDDOCK_LICENSE_KEY=
   </g>
 </svg>
 
-| `DEPLOYMENT_MODE` | `SENDDOCK_LICENSE_KEY` | Pro features |
-|---|---|---|
-| `self-hosted` (default) | empty | **Unlocked locally** — for development and evaluation. |
-| `self-hosted` | valid | Unlocked. License is checked on startup and re-validated periodically. |
-| `cloud` | empty | Locked (free tier). |
-| `cloud` | valid | Unlocked. |
+| `SENDDOCK_LICENSE_KEY` | Pro features |
+|---|---|
+| empty | **Locked** — Core only. |
+| valid | Unlocked. License is checked on startup and re-validated periodically. |
+| invalid / revoked | Locked after the next validation tick (24h grace from the last successful check). |
+
+`DEPLOYMENT_MODE` no longer changes Pro gating — the license requirement applies the same way to self-hosted and cloud. The mode still controls registration (`cloud` enables `POST /api/v1/auth/register`; `self-hosted` keeps registration disabled and relies on the setup screen).
 
 The validator only needs the license key — there is no API key, store ID or webhook secret to configure on the self-hosted side. Those are provisioned on the senddock.dev managed service that issues licenses.
 

--- a/docs/self-hosting/installation.md
+++ b/docs/self-hosting/installation.md
@@ -83,15 +83,10 @@ Open `http://your-domain.com` (or `http://localhost:8080` for a local test) and 
 
 | `SENDDOCK_LICENSE_KEY` | Behavior |
 |---|---|
-| empty (self-hosted) | All features unlocked locally — useful for evaluating Pro before buying. |
-| empty (cloud mode) | Free tier — Core features only (subscribers, templates, transactional sends, broadcasts, campaigns, BYO SMTP, click & open tracking). |
-| valid | Pro tier — unlocks the [Analytics dashboard](/guide/analytics) and [Webhooks management](/guide/webhooks). |
+| empty | Free tier — Core features only (projects, subscribers, templates, transactional sends, broadcasts, campaigns, BYO SMTP, click & open tracking, suppression list, webhook dispatcher). |
+| valid | Pro tier — adds the [Analytics dashboard](/guide/analytics), [Webhooks management UI](/guide/webhooks), and the audit log. |
 
 The image is the same in both cases. The license key, validated against a hosted endpoint, toggles the gated routes. Read more in the [pricing page](https://senddock.dev/pricing).
-
-::: warning Self-hosted with empty license unlocks everything
-This is intentional — local development should never need a license. If you self-host an instance that other people will use, set a real `SENDDOCK_LICENSE_KEY` (or accept that Pro features are free for those users). The "empty key = unlocked" behavior only fires when `DEPLOYMENT_MODE=self-hosted`, which is the default.
-:::
 
 ### Pinning a version in production
 

--- a/docs/self-hosting/installation.md
+++ b/docs/self-hosting/installation.md
@@ -95,7 +95,7 @@ The image is the same in both cases. The license key, validated against a hosted
 ```yaml
 services:
   senddock:
-    image: ghcr.io/arkhe-systems/senddock:0.5.1
+    image: ghcr.io/arkhe-systems/senddock:0.5.2
 ```
 
 See available tags on [GHCR](https://github.com/Arkhe-Systems/senddock/pkgs/container/senddock). Only versioned tags (`X.Y.Z`, `X.Y`, `X`) and `:latest` are public — pre-release builds (`:dev`) live in a separate, private package and are not intended for end users.

--- a/docs/self-hosting/updating.md
+++ b/docs/self-hosting/updating.md
@@ -45,7 +45,7 @@ Pin the version in `docker-compose.yml` to control update timing:
 ```yaml
 services:
   senddock:
-    image: ghcr.io/arkhe-systems/senddock:0.5.1
+    image: ghcr.io/arkhe-systems/senddock:0.5.2
 ```
 
 When you decide to upgrade, edit the tag, then `docker compose pull && docker compose up -d`.


### PR DESCRIPTION
## Critical security/license fix

Versions 0.5.0 and 0.5.1 shipped with a license validator that auto-unlocked every Pro feature on self-hosted deployments with an empty `SENDDOCK_LICENSE_KEY`. Anyone running the public image without a license has been getting Analytics, Webhooks management and Audit log for free.

This patch removes the auto-unlock branch entirely. An empty license key now leaves Pro locked in every deployment mode; Core stays fully usable as before.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/...` passes
- [x] Documentation swept for the obsolete wording in 7 files