### PR TITLE
v0.6.0 — workspaces, Team plan, in-app subscribe path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,19 @@ Releases are also published on [GitHub](https://github.com/arkhe-systems/senddoc
 
 ## [Unreleased]
 
-Targeted for the **0.6.0** release. Currently on the `dev` branch.
+_Nothing here yet. Track upcoming work on the [open issues](https://github.com/arkhe-systems/senddock/issues)._
+
+## [0.6.0] — 2026-04-30
+
+The "team launch" release. Workspaces with members and roles, a new Team plan above Pro, an in-app subscribe path through Lemon Squeezy, plus a long list of v0.6 quality-of-life features.
 
 ### Added
 
 - **Workspaces.** A workspace is a container for projects with its own member list. Authorization for project endpoints now scopes by workspace membership; existing single-user installs are migrated transparently (every user got a `My Workspace` with their projects under it). Workspace CRUD, listing your own workspaces and listing members stay free in Core.
 - **Roles & capabilities.** Four roles — `owner`, `admin`, `developer`, `viewer` — with a fixed capability matrix enforced at the handler level. Developers can `POST /send` (transactional) but not broadcast or edit templates; viewers are read-only; admins do everything except member management; owners do everything. The legacy `member` role is kept for backward compatibility (same access as `admin`).
 - **Team plan tier.** Multi-member workspaces, role management, and the new admin "Create user" endpoint (`POST /workspaces/{id}/users`) belong to a new **Team** plan above Pro. Without a Team-entitled `SENDDOCK_LICENSE_KEY` the endpoints return `402 Payment Required` and the Members page renders a paywall — the single-user flow stays free.
+- **In-app Subscribe links.** Pro and Team paywalls now drive directly to the Lemon Squeezy checkout for the right tier instead of bouncing the user back to the landing page. Pro's CTA pre-applies the `LAUNCH3FREE` launch coupon while it is active.
+- **Pro vs Team gating in the validator.** The Lemon Squeezy validator now classifies licenses by `variant_id` and returns the right tier in `Status.Tier`. `AllowsFeature(feature)` consults a feature → tier matrix so a Pro key cannot unlock Team features.
 - **Email validation on import (#43).** CSV/JSON imports now check syntax, MX records and a built-in disposable-domain list. Rejected rows surface in the import results modal with a per-row reason.
 - **File picker and drag-and-drop for CSV imports.** Replaces the textarea-only flow.
 - **Per-project suppression list (#42).** New `suppressions` table; `/send`, `/send/batch` and `/broadcast` skip suppressed recipients and account for them in the result counts. Existing unsubscribed subscribers are backfilled. Manage entries from the Suppressions tab inside a project (list, filter by reason, manual add, bulk import, remove).
@@ -34,6 +40,9 @@ Targeted for the **0.6.0** release. Currently on the `dev` branch.
 ### Fixed
 
 - `AppCheckbox` is now clickable outside `<label>` wrappers (the off-screen `peer sr-only` input did not catch clicks inside table cells).
+- Rate-limit middleware no longer poisons the session-expiry flow. The global per-IP cap is 600/min, `X-Forwarded-For` is parsed correctly behind a proxy, and the frontend distinguishes 429 from 401 so a burst of polling no longer dumps the user back to the login screen.
+- Project shell is responsive on mobile — sidebar collapses into a drawer below `md`, page-level headers wrap, every table sits inside `overflow-x-auto`.
+- `GET /workspaces/{id}/projects` now wraps the response with the same shape as `GET /projects` (was returning raw Go field names, broke `project.created_at` and `project.name` on the dashboard).
 
 ## [0.5.2] — 2026-04-30
 

--- a/backend/internal/version/version.go
+++ b/backend/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var Version = "0.5.2"
+var Version = "0.6.0"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,13 +16,17 @@ Pre-1.0 minor releases may contain breaking changes — check the version's note
 
 ## [Unreleased]
 
-Targeted for the **0.6.0** release. Currently on the `dev` branch.
+_Nothing here yet. Track upcoming work on the [open issues](https://github.com/arkhe-systems/senddock/issues)._
+
+## [0.6.0] — 2026-04-30
 
 ### Added
 
 - **Workspaces.** Multi-user collaboration with workspace-scoped projects. Existing single-user installs were backfilled — every user got a `My Workspace` with their projects under it. See [Workspaces guide](./guide/workspaces).
 - **Roles & capabilities.** Four roles (`owner`, `admin`, `developer`, `viewer`) with a fixed capability matrix. Developers can call `/send` (transactional) but cannot broadcast or edit templates; viewers are read-only; admins do everything except member management.
 - **Team plan tier.** Multi-member workspaces, role management and the admin "Create user" flow belong to a new **Team** plan above Pro. Without a Team license the endpoints return `402` and the Members page shows a paywall; single-user organization stays free.
+- **In-app Subscribe links to Lemon Squeezy.** Pro and Team paywalls jump straight to checkout for the right tier; Pro pre-applies the launch promo while it is active.
+- **Pro vs Team gating in the validator.** `Status.Tier` is exposed and `AllowsFeature(feature)` consults a feature → tier matrix, so a Pro license can no longer unlock Team-only endpoints.
 - **Email validation on import (#43).** CSV/JSON imports now check syntax, MX records and a built-in disposable-domain list. Rejected rows surface in the import results modal with a per-row reason.
 - **File picker and drag-and-drop for CSV imports.**
 - **Per-project suppression list (#42).** New `suppressions` table; `/send`, `/send/batch` and `/broadcast` skip suppressed recipients and account for them in the result counts. Existing unsubscribed subscribers are backfilled. Manage entries from the Suppressions tab inside a project.

--- a/frontend/src/components/ui/AppProPaywall.vue
+++ b/frontend/src/components/ui/AppProPaywall.vue
@@ -1,25 +1,53 @@
 <script setup lang="ts">
-defineProps<{
+import { computed } from 'vue'
+import { checkoutUrl, isLaunchPromoActive, LAUNCH_DISCOUNT_CODE, type Tier } from '@/config/checkout'
+
+const props = withDefaults(defineProps<{
     title: string
     description: string
-    cta?: string
-}>()
+    tier?: Tier
+}>(), {
+    tier: 'pro',
+})
 
-const PRICING_URL = 'https://senddock.dev/#pricing'
+const tierLabel = computed(() => (props.tier === 'team' ? 'Team' : 'Pro'))
+const tierPrice = computed(() => (props.tier === 'team' ? '$29/mo · $290/yr' : '$9/mo · $90/yr'))
+
+const buyHref = computed(() => {
+    return checkoutUrl(props.tier, props.tier === 'pro' && isLaunchPromoActive()
+        ? { discount: LAUNCH_DISCOUNT_CODE }
+        : undefined)
+})
+
+const promoVisible = computed(() => props.tier === 'pro' && isLaunchPromoActive())
 </script>
 
 <template>
     <div class="bg-zinc-900 border border-zinc-800 rounded-lg p-6 sm:p-8 text-center">
         <div class="inline-flex items-center gap-2 px-2.5 py-0.5 rounded-full bg-amber-500/15 text-amber-400 border border-amber-500/30 text-[11px] font-semibold tracking-wider uppercase mb-4">
-            Pro
+            {{ tierLabel }}
         </div>
         <h2 class="text-base sm:text-lg font-semibold text-white mb-2">{{ title }}</h2>
-        <p class="text-sm text-zinc-400 mb-6 max-w-md mx-auto">
-            {{ description }}
+        <p class="text-sm text-zinc-400 mb-6 max-w-md mx-auto">{{ description }}</p>
+
+        <div class="flex flex-col sm:flex-row items-center justify-center gap-2 mb-4">
+            <a :href="buyHref" target="_blank" rel="noopener"
+                class="inline-block px-5 py-2.5 text-sm font-semibold bg-white text-zinc-950 rounded-lg hover:bg-zinc-200 transition">
+                Subscribe to {{ tierLabel }} — {{ tierPrice }}
+            </a>
+            <a href="https://senddock.dev/#pricing" target="_blank" rel="noopener"
+                class="inline-block px-3 py-2 text-xs text-zinc-400 hover:text-white transition">
+                Compare plans →
+            </a>
+        </div>
+
+        <p v-if="promoVisible" class="text-xs text-amber-400 mb-3">
+            🎁 Code <span class="font-mono">{{ LAUNCH_DISCOUNT_CODE }}</span> applied · 3 months free for the first 50 customers
         </p>
-        <a :href="PRICING_URL" target="_blank" rel="noopener"
-            class="inline-block px-4 py-2 text-sm font-medium bg-white text-zinc-950 rounded-lg hover:bg-zinc-200 transition">
-            {{ cta || 'See Pro plans' }}
-        </a>
+
+        <p class="text-xs text-zinc-500 max-w-md mx-auto">
+            After payment you'll get a license key by email. Paste it into <span class="font-mono text-zinc-400">SENDDOCK_LICENSE_KEY</span> in your environment and restart.
+            <a href="https://docs.senddock.dev/self-hosting/configuration#plans-licensing" target="_blank" rel="noopener" class="underline decoration-zinc-700 hover:text-zinc-300">Read the docs</a>.
+        </p>
     </div>
 </template>

--- a/frontend/src/config/checkout.ts
+++ b/frontend/src/config/checkout.ts
@@ -1,0 +1,19 @@
+export const CHECKOUT_PRO = 'https://senddock.lemonsqueezy.com/checkout/buy/08756076-6890-4a78-ad53-2bcd15032360'
+export const CHECKOUT_TEAM = 'https://senddock.lemonsqueezy.com/checkout/buy/2f43c2fa-faa7-4ec9-b8cd-1faf44932219'
+
+export const LAUNCH_DISCOUNT_CODE = 'LAUNCH3FREE'
+export const LAUNCH_DISCOUNT_EXPIRES = '2026-05-10'
+
+export type Tier = 'pro' | 'team'
+
+export function checkoutUrl(tier: Tier, options?: { discount?: string }): string {
+    const base = tier === 'team' ? CHECKOUT_TEAM : CHECKOUT_PRO
+    const params = new URLSearchParams()
+    if (options?.discount) params.set('discount', options.discount)
+    const qs = params.toString()
+    return qs ? `${base}?${qs}` : base
+}
+
+export function isLaunchPromoActive(now: Date = new Date()): boolean {
+    return now < new Date(`${LAUNCH_DISCOUNT_EXPIRES}T23:59:59Z`)
+}

--- a/frontend/src/views/workspace/MembersView.vue
+++ b/frontend/src/views/workspace/MembersView.vue
@@ -20,6 +20,9 @@ import AppLoader from '@/components/ui/AppLoader.vue'
 import AppModal from '@/components/ui/AppModal.vue'
 import AppConfirmModal from '@/components/ui/AppConfirmModal.vue'
 import AppProPaywall from '@/components/ui/AppProPaywall.vue'
+import { checkoutUrl } from '@/config/checkout'
+
+const teamCheckoutUrl = checkoutUrl('team')
 
 const route = useRoute()
 const router = useRouter()
@@ -224,9 +227,9 @@ onMounted(async () => {
             <AppLoader v-if="loading" message="Loading members..." />
 
             <AppProPaywall v-else-if="paywall"
+                tier="team"
                 title="Team management is a Team plan feature"
-                description="Adding members, creating user accounts and changing roles require a SendDock Team license. Without one you can still organize your projects across multiple workspaces — you just stay the only member."
-                cta="See Team plan" />
+                description="Adding members, creating user accounts and changing roles require a SendDock Team license. Without one you can still organize your projects across multiple workspaces — you just stay the only member." />
 
             <template v-else>
                 <div class="flex flex-wrap items-center justify-between gap-3 mb-2">
@@ -251,9 +254,9 @@ onMounted(async () => {
                             <h2 class="text-base font-semibold text-white mb-1">You're on Pro — upgrade to Team to invite people</h2>
                             <p class="text-sm text-zinc-400">Adding members, creating user accounts and changing roles need the Team plan. Your Pro license stays untouched and you keep Analytics, Webhooks and Audit log.</p>
                         </div>
-                        <a href="https://senddock.dev/#pricing" target="_blank" rel="noopener"
+                        <a :href="teamCheckoutUrl" target="_blank" rel="noopener"
                             class="shrink-0 inline-block px-4 py-2 text-sm font-medium bg-white text-zinc-950 rounded-lg hover:bg-zinc-200 transition">
-                            See Team plan
+                            Upgrade to Team — $29/mo
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
Promotes the v0.6.0 release work from dev to main so the new container image inherits version 0.6.0, docs.senddock.dev rebuilds with the new pages, and the public release notes are accurate.

What lands (highlights, full list in CHANGELOG):

- Workspaces with members, four-role capability matrix, admin user creation flow
- New Team plan tier ($29/mo) gated separately from Pro via Lemon Squeezy variant_id
- In-app Subscribe buttons that drive directly to LS checkout, with LAUNCH3FREE pre-applied for Pro while the launch promo is active
- VitePress cleanUrls + _redirects so docs.senddock.dev resolves /api/authentication without the .html
- Landing rewrite: Pro $9 / Team $29 / Enterprise from $149 cards with proper Subscribe CTAs
- Many fixes: rate-limit no longer mistaken for session expiry, mobile shell responsive, /workspaces/{id}/projects response shape

After merge:

1. Tag v0.6.0 on this repo for the release notes URL.
2. Tag v0.6.0 on senddock-pro to trigger the public ghcr.io/arkhe-systems/senddock image build.
3. Verify ghcr.io/arkhe-systems/senddock:0.6.0 published and the GitHub Release on this repo.